### PR TITLE
🐛(tokens) fix windows generate tokens

### DIFF
--- a/.changeset/cool-bananas-float.md
+++ b/.changeset/cool-bananas-float.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-tokens": patch
+---
+
+fix windows generate tokens

--- a/packages/tokens/src/bin/Utils/Files.ts
+++ b/packages/tokens/src/bin/Utils/Files.ts
@@ -1,9 +1,10 @@
 import fs from "fs";
+import pathHelper from "path";
 import chalk from "chalk";
 
 export const put = (path: string, content: string) => {
   console.log("Generating tokens file to " + path + " ...");
-  const dir = path.substring(0, path.lastIndexOf("/"));
+  const dir = pathHelper.dirname(path);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }


### PR DESCRIPTION
## Purpose

The tokens generation was failing on windows because of the path separator, on windows the path separator is `\`.
