### PR TITLE
🐛(tokens) fix scss generator

### DIFF
--- a/.changeset/nasty-donuts-run.md
+++ b/.changeset/nasty-donuts-run.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-tokens": minor
+---
+
+Fix SassGenerator

--- a/packages/tokens/src/bin/Generators/JsGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/JsGenerator.spec.ts
@@ -24,7 +24,7 @@ describe("JsGenerator", () => {
     await run(["", "", "-g", "js"]);
     expect(fs.existsSync(tokensFile)).toEqual(true);
     expect(fs.readFileSync(tokensFile).toString()).toMatchInlineSnapshot(`
-      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
+      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000","ternary-900":"#022858"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
       "
     `);
   });

--- a/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
@@ -26,26 +26,26 @@ describe("SassGenerator", () => {
     expect(fs.existsSync(sassFile)).toEqual(true);
     expect(fs.readFileSync(sassFile).toString()).toMatchInlineSnapshot(`
       "$colors: (
-        primary: #055FD2,
-        secondary: #DA0000,
-        ternary: (
-          900: #022858
+        'primary': #055FD2,
+        'secondary': #DA0000,
+        'ternary': (
+          '900': #022858
         )
       );
       $fontFamilies: (
-        base: Roboto
+        'base': Roboto
       );
       $fontSizes: (
-        m: 1rem
+        'm': 1rem
       );
       $fontWeights: (
-        medium: 400
+        'medium': 400
       );
       $spacings: (
-        s: 1rem
+        's': 1rem
       );
       $transitions: (
-        ease: linear
+        'ease': linear
       );
       "
     `);

--- a/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
@@ -27,7 +27,10 @@ describe("SassGenerator", () => {
     expect(fs.readFileSync(sassFile).toString()).toMatchInlineSnapshot(`
       "$colors: (
         primary: #055FD2,
-        secondary: #DA0000
+        secondary: #DA0000,
+        ternary: (
+          900: #022858
+        )
       );
       $fontFamilies: (
         base: Roboto

--- a/packages/tokens/src/bin/Generators/SassGenerator.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.ts
@@ -55,7 +55,19 @@ const generateTransitionsSassMap = (tokens: Tokens) => {
 };
 
 function JSONToSassMap(json: Object) {
-  return JSON.stringify(json, null, 2)
+  function deepQuoteObjectKeys(object: Object) {
+    return Object.entries(object).reduce(
+      (acc, [key, value]): Record<string, any> => ({
+        ...acc,
+        [`'${key}'`]:
+          typeof value === "object" ? deepQuoteObjectKeys(value) : value,
+      }),
+      {}
+    );
+  }
+  const jsonWithQuotedKeys = deepQuoteObjectKeys(json);
+
+  return JSON.stringify(jsonWithQuotedKeys, null, 2)
     .replace(/{/g, "(")
     .replace(/}/g, ")")
     .replace(/"/g, "");

--- a/packages/tokens/src/bin/Generators/TsGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/TsGenerator.spec.ts
@@ -24,7 +24,7 @@ describe("TsGenerator", () => {
     await run(["", "", "-g", "ts"]);
     expect(fs.existsSync(tokensFile)).toEqual(true);
     expect(fs.readFileSync(tokensFile).toString()).toMatchInlineSnapshot(`
-      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
+      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000","ternary-900":"#022858"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
       "
     `);
   });

--- a/packages/tokens/src/bin/__mocks__/cunningham.ts
+++ b/packages/tokens/src/bin/__mocks__/cunningham.ts
@@ -3,6 +3,7 @@ module.exports = {
     colors: {
       primary: "#055FD2",
       secondary: "#DA0000",
+      "ternary-900": "#022858",
     },
     font: {
       sizes: {

--- a/packages/tokens/src/bin/tests/assets/expected-default-cunningham-tokens.css
+++ b/packages/tokens/src/bin/tests/assets/expected-default-cunningham-tokens.css
@@ -1,6 +1,7 @@
 :root {
 	--c--theme--colors--primary: #055FD2;
 	--c--theme--colors--secondary: #DA0000;
+	--c--theme--colors--ternary-900: #022858;
 	--c--theme--font--sizes--m: 1rem;
 	--c--theme--font--weights--medium: 400;
 	--c--theme--font--families--base: Roboto;

--- a/packages/tokens/src/bin/tests/assets/expected-js-cunningham-tokens.css
+++ b/packages/tokens/src/bin/tests/assets/expected-js-cunningham-tokens.css
@@ -1,6 +1,7 @@
 :root {
 	--c--theme--colors--primary: AntiqueWhite;
 	--c--theme--colors--secondary: #DA0000;
+	--c--theme--colors--ternary-900: #022858;
 	--c--theme--font--sizes--m: 1rem;
 	--c--theme--font--weights--medium: 400;
 	--c--theme--font--families--base: Roboto;

--- a/packages/tokens/src/bin/tests/assets/expected-with-utility-classes-cunningham-tokens.css
+++ b/packages/tokens/src/bin/tests/assets/expected-with-utility-classes-cunningham-tokens.css
@@ -1,6 +1,7 @@
 :root {
 	--c--theme--colors--primary: #055FD2;
 	--c--theme--colors--secondary: #DA0000;
+	--c--theme--colors--ternary-900: #022858;
 	--c--theme--font--sizes--m: 1rem;
 	--c--theme--font--weights--medium: 400;
 	--c--theme--font--families--base: Roboto;
@@ -8,8 +9,10 @@
 	--c--theme--transitions--ease: linear;
 } .clr-primary { color: var(--c--theme--colors--primary); }
 .clr-secondary { color: var(--c--theme--colors--secondary); }
+.clr-ternary-900 { color: var(--c--theme--colors--ternary-900); }
 .bg-primary { background-color: var(--c--theme--colors--primary); }
 .bg-secondary { background-color: var(--c--theme--colors--secondary); }
+.bg-ternary-900 { background-color: var(--c--theme--colors--ternary-900); }
 .fw-medium { font-weight: var(--c--theme--font--weights--medium); }
 .fs-m { font-size: var(--c--theme--font--sizes--m); }
 .f-base { font-family: var(--c--theme--font--families--base); }


### PR DESCRIPTION
scss maps expect keys between quotes like:
```
$map = (
  'key': value,
)
```