### PR TITLE
Refactor/sass generator

### DIFF
--- a/.changeset/calm-ties-hear.md
+++ b/.changeset/calm-ties-hear.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-tokens": minor
+---
+
+Suffix all sass maps with the `!default` map

--- a/.changeset/many-taxis-promise.md
+++ b/.changeset/many-taxis-promise.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-tokens": minor
+---
+
+Do not generate sass sub maps

--- a/packages/tokens/src/bin/Generators/JsGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/JsGenerator.spec.ts
@@ -24,7 +24,7 @@ describe("JsGenerator", () => {
     await run(["", "", "-g", "js"]);
     expect(fs.existsSync(tokensFile)).toEqual(true);
     expect(fs.readFileSync(tokensFile).toString()).toMatchInlineSnapshot(`
-      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000","ternary-900":"#022858"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
+      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000","ternary-900":"#022858","ogre-odor-is-orange-indeed":"#FD5240"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
       "
     `);
   });

--- a/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
@@ -28,9 +28,8 @@ describe("SassGenerator", () => {
       "$colors: (
         'primary': #055FD2,
         'secondary': #DA0000,
-        'ternary': (
-          '900': #022858
-        )
+        'ternary-900': #022858,
+        'ogre-odor-is-orange-indeed': #FD5240
       );
       $fontFamilies: (
         'base': Roboto

--- a/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.spec.ts
@@ -30,22 +30,22 @@ describe("SassGenerator", () => {
         'secondary': #DA0000,
         'ternary-900': #022858,
         'ogre-odor-is-orange-indeed': #FD5240
-      );
+      ) !default;
       $fontFamilies: (
         'base': Roboto
-      );
+      ) !default;
       $fontSizes: (
         'm': 1rem
-      );
+      ) !default;
       $fontWeights: (
         'medium': 400
-      );
+      ) !default;
       $spacings: (
         's': 1rem
-      );
+      ) !default;
       $transitions: (
         'ease': linear
-      );
+      ) !default;
       "
     `);
   });

--- a/packages/tokens/src/bin/Generators/SassGenerator.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.ts
@@ -23,12 +23,7 @@ const generateSassMaps = (tokens: Tokens) => {
 // for a color with shades.
 // Example: `primary-500: #000` will return `primary: (500: #000)`
 const generateColorsSassMap = (tokens: Tokens) => {
-  const colors = Object.entries(tokens.theme.colors).reduce(
-    propertiesReducer,
-    {}
-  );
-
-  return `$colors: ${JSONToSassMap(colors)};`;
+  return `$colors: ${JSONToSassMap(tokens.theme.colors)};`;
 };
 const generateFontSassMap = (tokens: Tokens) => {
   return [
@@ -71,22 +66,4 @@ function JSONToSassMap(json: Object) {
     .replace(/{/g, "(")
     .replace(/}/g, ")")
     .replace(/"/g, "");
-}
-
-function propertiesReducer(
-  propertyMap: Record<string, string | Record<string, string>>,
-  [key, value]: [string, string]
-) {
-  const [property, subProperty] = key.split("-");
-
-  if (subProperty) {
-    if (propertyMap[property] === undefined) {
-      propertyMap[property] = {};
-    }
-    (propertyMap[property] as Record<string, string>)[subProperty] = value;
-  } else {
-    propertyMap[property] = value;
-  }
-
-  return propertyMap;
 }

--- a/packages/tokens/src/bin/Generators/SassGenerator.ts
+++ b/packages/tokens/src/bin/Generators/SassGenerator.ts
@@ -49,7 +49,7 @@ const generateTransitionsSassMap = (tokens: Tokens) => {
   return `$transitions: ${JSONToSassMap(tokens.theme.transitions)};`;
 };
 
-function JSONToSassMap(json: Object) {
+function JSONToSassMap(json: Object, isDefault = true) {
   function deepQuoteObjectKeys(object: Object) {
     return Object.entries(object).reduce(
       (acc, [key, value]): Record<string, any> => ({
@@ -65,5 +65,6 @@ function JSONToSassMap(json: Object) {
   return JSON.stringify(jsonWithQuotedKeys, null, 2)
     .replace(/{/g, "(")
     .replace(/}/g, ")")
-    .replace(/"/g, "");
+    .replace(/"/g, "")
+    .concat(isDefault ? " !default" : "");
 }

--- a/packages/tokens/src/bin/Generators/TsGenerator.spec.ts
+++ b/packages/tokens/src/bin/Generators/TsGenerator.spec.ts
@@ -24,7 +24,7 @@ describe("TsGenerator", () => {
     await run(["", "", "-g", "ts"]);
     expect(fs.existsSync(tokensFile)).toEqual(true);
     expect(fs.readFileSync(tokensFile).toString()).toMatchInlineSnapshot(`
-      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000","ternary-900":"#022858"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
+      "export const tokens = {"theme":{"colors":{"primary":"#055FD2","secondary":"#DA0000","ternary-900":"#022858","ogre-odor-is-orange-indeed":"#FD5240"},"font":{"sizes":{"m":"1rem"},"weights":{"medium":400},"families":{"base":"Roboto"}},"spacings":{"s":"1rem"},"transitions":{"ease":"linear"}}};
       "
     `);
   });

--- a/packages/tokens/src/bin/__mocks__/cunningham.ts
+++ b/packages/tokens/src/bin/__mocks__/cunningham.ts
@@ -4,6 +4,7 @@ module.exports = {
       primary: "#055FD2",
       secondary: "#DA0000",
       "ternary-900": "#022858",
+      "ogre-odor-is-orange-indeed": "#FD5240",
     },
     font: {
       sizes: {

--- a/packages/tokens/src/bin/tests/assets/expected-default-cunningham-tokens.css
+++ b/packages/tokens/src/bin/tests/assets/expected-default-cunningham-tokens.css
@@ -2,6 +2,7 @@
 	--c--theme--colors--primary: #055FD2;
 	--c--theme--colors--secondary: #DA0000;
 	--c--theme--colors--ternary-900: #022858;
+	--c--theme--colors--ogre-odor-is-orange-indeed: #FD5240;
 	--c--theme--font--sizes--m: 1rem;
 	--c--theme--font--weights--medium: 400;
 	--c--theme--font--families--base: Roboto;

--- a/packages/tokens/src/bin/tests/assets/expected-js-cunningham-tokens.css
+++ b/packages/tokens/src/bin/tests/assets/expected-js-cunningham-tokens.css
@@ -2,6 +2,7 @@
 	--c--theme--colors--primary: AntiqueWhite;
 	--c--theme--colors--secondary: #DA0000;
 	--c--theme--colors--ternary-900: #022858;
+	--c--theme--colors--ogre-odor-is-orange-indeed: #FD5240;
 	--c--theme--font--sizes--m: 1rem;
 	--c--theme--font--weights--medium: 400;
 	--c--theme--font--families--base: Roboto;

--- a/packages/tokens/src/bin/tests/assets/expected-with-utility-classes-cunningham-tokens.css
+++ b/packages/tokens/src/bin/tests/assets/expected-with-utility-classes-cunningham-tokens.css
@@ -2,6 +2,7 @@
 	--c--theme--colors--primary: #055FD2;
 	--c--theme--colors--secondary: #DA0000;
 	--c--theme--colors--ternary-900: #022858;
+	--c--theme--colors--ogre-odor-is-orange-indeed: #FD5240;
 	--c--theme--font--sizes--m: 1rem;
 	--c--theme--font--weights--medium: 400;
 	--c--theme--font--families--base: Roboto;
@@ -10,9 +11,11 @@
 } .clr-primary { color: var(--c--theme--colors--primary); }
 .clr-secondary { color: var(--c--theme--colors--secondary); }
 .clr-ternary-900 { color: var(--c--theme--colors--ternary-900); }
+.clr-ogre-odor-is-orange-indeed { color: var(--c--theme--colors--ogre-odor-is-orange-indeed); }
 .bg-primary { background-color: var(--c--theme--colors--primary); }
 .bg-secondary { background-color: var(--c--theme--colors--secondary); }
 .bg-ternary-900 { background-color: var(--c--theme--colors--ternary-900); }
+.bg-ogre-odor-is-orange-indeed { background-color: var(--c--theme--colors--ogre-odor-is-orange-indeed); }
 .fw-medium { font-weight: var(--c--theme--font--weights--medium); }
 .fs-m { font-size: var(--c--theme--font--sizes--m); }
 .f-base { font-family: var(--c--theme--font--families--base); }


### PR DESCRIPTION
## Purpose

Currently, if a color token key contains a dash, we split this key to create sub maps. First it appears a good idea but in real case not. Indeed, with this logic we are not able to use color key containing dashed in their name that is weird. Furthermore, if we need to create sub maps, this structure should appear within the token declaration module.

Then, we also want a cunningham consumer is able to override generated sass maps. In order to that, we decide to suffix, by default, all sass maps with the flag `!default`.

## Proposal
- [x] Do no create sass sub maps anymore
- [x] Suffix all sass maps with the flag `!default` 