### PR TITLE
🔖(react) bump to 0.6.1

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,9 +1,14 @@
 # @openfun/cunningham-react
 
+## 0.6.1
+
+### Patch Changes
+
+- 4777a75: fix "exports" attribute of package.json. Default condition must be last one.
+
 ## 0.6.0
 
 ### Minor Changes
-
 - 2ff5fc5: add Select component
 - 2ff5fc5: add forwardRef to Button
 - 2ff5fc5: create a generic LabelledBox
@@ -75,7 +80,8 @@
 - 4ebbf16: Add package
 - 4ebbf16: Add component's tokens handling
 
-[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.6.0...main
+[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.6.1...main
+[0.6.1]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.6.0...0.6.1
 [0.6.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.5.0...0.6.0
 [0.5.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.4.0...0.5.0
 [0.4.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.3.0...0.4.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfun/cunningham-react",
   "private": false,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Purpose

Release @openfun/cunningham-react 0.6.1

### Patch Changes

- Fix "exports" attribute of package.json. Default condition must be last one.