### PR TITLE
🐛(react) fix storybook deploy

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,8 @@
     "coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "deploy-storybook": "storybook-to-ghpages"
+    "predeploy-storybook": "yarn build-storybook && touch ./storybook-static/.nojekyll",
+    "deploy-storybook": "storybook-to-ghpages --existing-output-dir ./storybook-static"
   },
   "dependencies": {
     "@fontsource/material-icons": "4.5.4",


### PR DESCRIPTION
The static storybook deployment to github pages was throwing 404 errors for a file beginning with a underscore, adding a .nojekyll disables conflicts due to the default behavio of github pages.