### PR TITLE
♻️(react) fix Storybook source blocks

### DIFF
--- a/.changeset/fast-bulldogs-cross.md
+++ b/.changeset/fast-bulldogs-cross.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+fix Storybook source blocks

--- a/.changeset/stale-hotels-jump.md
+++ b/.changeset/stale-hotels-jump.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+migrate ArgsTable to ArgTypes and rework imports

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -2,7 +2,7 @@ import { StorybookConfig } from "@storybook/react-vite";
 import remarkGfm from "remark-gfm";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/packages/react/src/components/Button/index.mdx
+++ b/packages/react/src/components/Button/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, Source, ArgTypes } from '@storybook/blocks';
 import { Button } from "./index";
 import * as Stories from './index.stories';
 
@@ -56,7 +56,7 @@ The button can be disabled. The disabled button will render the same no matter w
 
 You can use all the props of the native html `<button>` element props plus the following.
 
-<ArgsTable of={Button} />
+<ArgTypes of={Button} />
 
 
 

--- a/packages/react/src/components/Button/index.mdx
+++ b/packages/react/src/components/Button/index.mdx
@@ -1,9 +1,8 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { Button } from "./index";
+import * as Stories from './index.stories';
 
-<Meta title="Components/Button/Doc" component={Button}/>
-
-export const Template = (args) => <Button {...args} />;
+<Meta of={Stories}/>
 
 # Button
 

--- a/packages/react/src/components/Button/index.stories.tsx
+++ b/packages/react/src/components/Button/index.stories.tsx
@@ -1,39 +1,37 @@
-import { Meta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { Button } from "./index";
 
-export default {
+const meta: Meta<typeof Button> = {
   title: "Components/Button",
   component: Button,
-  argTypes: {
-    disabled: {
-      control: "boolean",
-    },
-  },
-} as Meta<typeof Button>;
+};
 
-export const Primary = {
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
   args: {
     children: "Primary",
     color: "primary",
   },
 };
 
-export const Secondary = {
+export const Secondary: Story = {
   args: {
     children: "Secondary",
     color: "secondary",
   },
 };
 
-export const Tertiary = {
+export const Tertiary: Story = {
   args: {
     children: "Tertiary",
     color: "tertiary",
   },
 };
 
-export const Disabled = {
+export const Disabled: Story = {
   args: {
     children: "Disabled",
     color: "primary",
@@ -41,14 +39,14 @@ export const Disabled = {
   },
 };
 
-export const Danger = {
+export const Danger: Story = {
   args: {
     children: "Danger",
     color: "danger",
   },
 };
 
-export const Small = {
+export const Small: Story = {
   args: {
     children: "Primary",
     color: "primary",
@@ -56,7 +54,7 @@ export const Small = {
   },
 };
 
-export const IconLeft = {
+export const IconLeft: Story = {
   args: {
     children: "Icon",
     icon: (
@@ -79,7 +77,7 @@ export const IconLeft = {
   },
 };
 
-export const IconRight = {
+export const IconRight: Story = {
   args: {
     children: "Icon",
     iconPosition: "right",
@@ -103,7 +101,7 @@ export const IconRight = {
   },
 };
 
-export const IconOnly = {
+export const IconOnly: Story = {
   args: {
     "aria-label": "Button with only an icon",
     icon: (

--- a/packages/react/src/components/DataGrid/index.mdx
+++ b/packages/react/src/components/DataGrid/index.mdx
@@ -2,10 +2,9 @@ import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { DataGrid } from './index';
 import { SimpleDataGrid } from './SimpleDataGrid';
 import { DataList } from './DataList';
+import * as Stories from './index.stories';
 
-<Meta title="Components/DataGrid/Doc" component={DataGrid}/>
-
-export const Template = (args) => <DataGrid {...args} />;
+<Meta of={Stories}/>
 
 # DataGrid
 

--- a/packages/react/src/components/DataGrid/index.mdx
+++ b/packages/react/src/components/DataGrid/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, Source, ArgTypes } from '@storybook/blocks';
 import { DataGrid } from './index';
 import { SimpleDataGrid } from './SimpleDataGrid';
 import { DataList } from './DataList';
@@ -45,7 +45,7 @@ Here a quick usage example
 
 ### Props
 
-<ArgsTable of={DataList} />
+<ArgTypes of={DataList} />
 
 ## SimpleDataGrid
 
@@ -82,7 +82,7 @@ their states.
 
 ### Props
 
-<ArgsTable of={SimpleDataGrid} />
+<ArgTypes of={SimpleDataGrid} />
 
 ## DataGrid
 
@@ -102,7 +102,7 @@ control over the state of the table, like being able to use `useEffect` to fetch
 
 ### Props
 
-<ArgsTable of={DataGrid} />
+<ArgTypes of={DataGrid} />
 
 ## Columns
 

--- a/packages/react/src/components/Forms/Checkbox/index.mdx
+++ b/packages/react/src/components/Forms/Checkbox/index.mdx
@@ -1,5 +1,6 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, ArgTypes } from '@storybook/blocks';
 import * as Stories from './index.stories';
+import { Checkbox } from './index';
 
 <Meta of={Stories}/>
 
@@ -83,6 +84,10 @@ You can also define `state`, `text` props on the group component
   <Story id="components-forms-checkbox--group-error"/>
   <Story id="components-forms-checkbox--group-success"/>
 </Canvas>
+
+### Props
+
+<ArgTypes of={Checkbox} />
 
 ## Design tokens
 

--- a/packages/react/src/components/Forms/Checkbox/index.mdx
+++ b/packages/react/src/components/Forms/Checkbox/index.mdx
@@ -1,7 +1,7 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
-import { Checkbox } from "./index";
+import * as Stories from './index.stories';
 
-<Meta title="Components/Forms/Checkbox/Doc" component={Checkbox}/>
+<Meta of={Stories}/>
 
 # Checkbox
 

--- a/packages/react/src/components/Forms/Field/index.mdx
+++ b/packages/react/src/components/Forms/Field/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Meta, ArgTypes } from '@storybook/blocks';
 import { Field } from "./index";
 import * as Stories from './index.stories';
 
@@ -23,4 +23,4 @@ available design token to do so.
 
 ## Props
 
-<ArgsTable of={Field} exclude={["compact"]} />
+<ArgTypes of={Field} exclude={["compact"]} />

--- a/packages/react/src/components/Forms/Field/index.mdx
+++ b/packages/react/src/components/Forms/Field/index.mdx
@@ -1,9 +1,8 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { Field } from "./index";
+import * as Stories from './index.stories';
 
-<Meta title="Components/Forms/Field/Doc" component={Field}/>
-
-export const Template = (args) => <Field {...args} />;
+<Meta of={Stories}/>
 
 # Field
 

--- a/packages/react/src/components/Forms/Input/index.mdx
+++ b/packages/react/src/components/Forms/Input/index.mdx
@@ -1,9 +1,8 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { Input } from "./index";
+import * as Stories from './index.stories';
 
-<Meta title="Components/Forms/Input/Doc" component={Input}/>
-
-export const Template = (args) => <Input {...args} />;
+<Meta of={Stories}/>
 
 # Input
 

--- a/packages/react/src/components/Forms/Input/index.mdx
+++ b/packages/react/src/components/Forms/Input/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, Source, ArgTypes } from '@storybook/blocks';
 import { Input } from "./index";
 import * as Stories from './index.stories';
 
@@ -110,7 +110,7 @@ You can use the `ref` props to get a reference to the input element. The ref to 
 
 You can use all the props of the native html `<input>` element props plus the following.
 
-<ArgsTable of={Input} />
+<ArgTypes of={Input} />
 
 ## Design tokens
 

--- a/packages/react/src/components/Forms/Radio/index.mdx
+++ b/packages/react/src/components/Forms/Radio/index.mdx
@@ -1,7 +1,8 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { Radio } from "./index";
+import * as Stories from './index.stories';
 
-<Meta title="Components/Forms/Radio/Doc" component={Radio}/>
+<Meta of={Stories}/>
 
 # Radio
 

--- a/packages/react/src/components/Forms/Radio/index.mdx
+++ b/packages/react/src/components/Forms/Radio/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, ArgTypes } from '@storybook/blocks';
 import { Radio } from "./index";
 import * as Stories from './index.stories';
 
@@ -83,6 +83,10 @@ You can also define `state`, `text` props on the group component
   <Story id="components-forms-radio--group-error"/>
   <Story id="components-forms-radio--group-success"/>
 </Canvas>
+
+### Props
+
+<ArgTypes of={Radio} />
 
 ## Design tokens
 

--- a/packages/react/src/components/Forms/Select/index.mdx
+++ b/packages/react/src/components/Forms/Select/index.mdx
@@ -1,9 +1,8 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { Select } from "./index";
+import * as Stories from './mono.stories';
 
-<Meta title="Components/Forms/Select/Doc" component={Select}/>
-
-export const Template = (args) => <Input {...args} />;
+<Meta of={Stories} name="Docs"/>
 
 # Select
 

--- a/packages/react/src/components/Forms/Select/index.mdx
+++ b/packages/react/src/components/Forms/Select/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, Source, ArgTypes } from '@storybook/blocks';
 import { Select } from "./index";
 import * as Stories from './mono.stories';
 
@@ -88,7 +88,7 @@ using the component in a controlled way.
 
 The props of this component are as close as possible to the native select component. You can see the list of props below.
 
-<ArgsTable of={Select} />
+<ArgTypes of={Select} />
 
 ## Design tokens
 

--- a/packages/react/src/components/Pagination/index.mdx
+++ b/packages/react/src/components/Pagination/index.mdx
@@ -1,7 +1,8 @@
 import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
 import { Pagination, usePagination } from './index';
+import * as Stories from './index.stories';
 
-<Meta title="Components/Pagination/Doc" component={Pagination}/>
+<Meta of={Stories}/>
 
 # Pagination
 

--- a/packages/react/src/components/Pagination/index.mdx
+++ b/packages/react/src/components/Pagination/index.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story, Source, ArgsTable } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, Source, ArgTypes } from '@storybook/blocks';
 import { Pagination, usePagination } from './index';
 import * as Stories from './index.stories';
 
@@ -61,8 +61,8 @@ You can also set the page programmatically, for example, if you want to use a qu
 
 ### `<Pagination/>` component
 
-<ArgsTable of={Pagination} />
+<ArgTypes of={Pagination} />
 
 ### `usePagination` hook
 
-<ArgsTable of={usePagination} />
+<ArgTypes of={usePagination} />


### PR DESCRIPTION
Due to the recent upgrade to Storybook 7, the source blocks of Canvases were broken, they were only showing args. This was mainly due to the fact that as of Storybook 7 the meta tags of the MDX files have changed, thus causing the issue. These are now based on imports.