### PR TITLE
🐛(react) export `DatePicker` components

### DIFF
--- a/.changeset/shiny-donkeys-cross.md
+++ b/.changeset/shiny-donkeys-cross.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+Export date picker components

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,6 +12,7 @@ export * from "./components/Forms/Input";
 export * from "./components/Forms/Radio";
 export * from "./components/Forms/Select";
 export * from "./components/Forms/Switch";
+export * from "./components/Forms/DatePicker";
 export * from "./components/Loader";
 export * from "./components/Pagination";
 export * from "./components/Provider";


### PR DESCRIPTION
Date picker components were not exported in the global `index.ts`