### PR TITLE
Feature/international-calendar

### DIFF
--- a/.changeset/polite-mails-remain.md
+++ b/.changeset/polite-mails-remain.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+Add calendar system customization in `DatePicker` component

--- a/packages/react/src/components/Forms/DatePicker/DatePicker.spec.tsx
+++ b/packages/react/src/components/Forms/DatePicker/DatePicker.spec.tsx
@@ -1131,4 +1131,160 @@ describe("<DatePicker/>", () => {
     await user.keyboard("{ArrowRight}");
     expectFocusedMonthToBeEqual(nextMonthValue);
   });
+
+  it("uses the locale props calendar system", async () => {
+    const user = userEvent.setup();
+    render(
+      <CunninghamProvider>
+        <DatePicker
+          label="Pick a date"
+          locale="hi-IN-u-ca-indian"
+          defaultValue="2023-06-25"
+        />
+      </CunninghamProvider>
+    );
+
+    const input = (await screen.findAllByRole("button"))[0];
+
+    // Toggle button opens the calendar.
+    await user.click(input);
+    expectCalendarToBeOpen();
+    expectDateFieldToBeDisplayed();
+
+    // Make sure dateField is in the right locale
+    const dateFieldContent = screen.getByRole("presentation").textContent;
+    expect(dateFieldContent).eq("4/4/1945 शक");
+
+    // Make sure month is in the right locale
+    const focusedMonth = screen
+      .getByRole("combobox", {
+        name: "Select a month",
+      })!
+      .textContent?.replace("arrow_drop_down", "");
+    expect(focusedMonth).eq("आषाढ़");
+
+    // Make sure year is in the right locale
+    const focusedYear = screen
+      .getByRole("combobox", {
+        name: "Select a year",
+      })!
+      .textContent?.replace("arrow_drop_down", "");
+    expect(focusedYear).eq("1945 शक");
+
+    // Make sure weekdays are in the right locale
+    screen.getByText("रवि");
+    screen.getByText("सोम");
+    screen.getByText("मंगल");
+    screen.getByText("बुध");
+    screen.getByText("गुरु");
+    screen.getByText("शुक्र");
+    screen.getByText("शनि");
+  });
+
+  it("uses the cunningham provider props calendar systems", async () => {
+    const user = userEvent.setup();
+    render(
+      <CunninghamProvider currentLocale="fr-FR">
+        <DatePicker label="Pick a date" defaultValue="2023-06-25" />
+      </CunninghamProvider>
+    );
+
+    const input = (await screen.findAllByRole("button"))[0];
+
+    // Toggle button opens the calendar.
+    await user.click(input);
+    expectCalendarToBeOpen();
+    expectDateFieldToBeDisplayed();
+
+    // Make sure dateField is in the right locale
+    const dateFieldContent = screen.getByRole("presentation").textContent;
+    expect(dateFieldContent).eq("25/06/2023");
+
+    // Make sure month is in the right locale
+    const focusedMonth = screen
+      .getByRole("combobox", {
+        name: "Sélectionner un mois",
+      })!
+      .textContent?.replace("arrow_drop_down", "");
+    expect(focusedMonth).eq("juin");
+
+    // Make sure year is in the right locale
+    const focusedYear = screen
+      .getByRole("combobox", {
+        name: "Sélectionner une année",
+      })!
+      .textContent?.replace("arrow_drop_down", "");
+    expect(focusedYear).eq("2023");
+
+    // Make sure weekdays are in the right locale
+    screen.getByText("lun.");
+    screen.getByText("mar.");
+    screen.getByText("mer.");
+    screen.getByText("jeu.");
+    screen.getByText("ven.");
+    screen.getByText("sam.");
+    screen.getByText("dim.");
+  });
+
+  it("makes sure the locale props override the cunningham provider calendar system", async () => {
+    const user = userEvent.setup();
+    render(
+      <CunninghamProvider currentLocale="fr-FR">
+        <DatePicker
+          label="Pick a date"
+          defaultValue="2023-06-25"
+          locale="hi-IN-u-ca-indian"
+        />
+      </CunninghamProvider>
+    );
+
+    const input = (await screen.findAllByRole("button"))[0];
+
+    // Toggle button opens the calendar.
+    await user.click(input);
+    expectCalendarToBeOpen();
+    expectDateFieldToBeDisplayed();
+
+    // Make sure dateField is in the right locale
+    const dateFieldContent = screen.getByRole("presentation").textContent;
+    expect(dateFieldContent).eq("4/4/1945 शक");
+
+    // Make sure month is in the right locale
+    // And aria-label uses the right translation.
+    const focusedMonth = screen
+      .getByRole("combobox", {
+        name: "Sélectionner un mois",
+      })!
+      .textContent?.replace("arrow_drop_down", "");
+    expect(focusedMonth).eq("आषाढ़");
+
+    // Make sure year is in the right locale
+    // And aria-label uses the right translation.
+    const focusedYear = screen
+      .getByRole("combobox", {
+        name: "Sélectionner une année",
+      })!
+      .textContent?.replace("arrow_drop_down", "");
+    expect(focusedYear).eq("1945 शक");
+
+    // Make sure weekdays are in the right locale
+    screen.getByText("रवि");
+    screen.getByText("सोम");
+    screen.getByText("मंगल");
+    screen.getByText("बुध");
+    screen.getByText("गुरु");
+    screen.getByText("शुक्र");
+    screen.getByText("शनि");
+  });
+
+  it("has a wrong locale props", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(() =>
+      render(
+        <CunninghamProvider>
+          <DatePicker label="Pick a date" locale="111" />
+        </CunninghamProvider>
+      )
+    ).toThrow("Incorrect locale information provided");
+  });
 });

--- a/packages/react/src/components/Forms/DatePicker/index.mdx
+++ b/packages/react/src/components/Forms/DatePicker/index.mdx
@@ -122,6 +122,16 @@ When passing an invalid date, for example outside of the valid range, the DatePi
   <Story id="components-forms-datepicker--invalid-value"/>
 </Canvas>
 
+## International calendars
+
+When passing a locale value to the DatePicker components, dates would be automatically displayed in the appropriate calendar system.
+By default, the DatePicker component uses the CunninghamProvider locale.
+
+<Canvas sourceState="shown">
+  <Story id="components-forms-datepicker--custom-locale"/>
+  <Story id="components-forms-datepicker--cunningham-locale"/>
+</Canvas>
+
 ## Props
 
 You can see the list of props below.

--- a/packages/react/src/components/Forms/DatePicker/index.mdx
+++ b/packages/react/src/components/Forms/DatePicker/index.mdx
@@ -12,7 +12,7 @@ import { DateRangePicker } from "./index";
 Cunningham provides a versatile DatePicker component to select or input a date in your form. It uses the headless
 UI components provided by [React-Spectrum](https://react-spectrum.adobe.com/react-aria/useDatePicker.html) from Adobe.
 
-> For now it is only available for single date selection, a range date picker and time features will be available soon.
+> Time features will be available soon.
 
 
 ## Basic

--- a/packages/react/src/components/Forms/DatePicker/index.stories.tsx
+++ b/packages/react/src/components/Forms/DatePicker/index.stories.tsx
@@ -95,6 +95,26 @@ export const Fullwidth = {
   },
 };
 
+export const CustomLocale = () => (
+  <div style={{ minHeight: "400px" }}>
+    <CunninghamProvider>
+      <DatePicker
+        label="Pick a date"
+        locale="hi-IN-u-ca-indian"
+        defaultValue="2023-06-25"
+      />
+    </CunninghamProvider>
+  </div>
+);
+
+export const CunninghamLocale = () => (
+  <div style={{ minHeight: "400px" }}>
+    <CunninghamProvider currentLocale="fr-FR">
+      <DatePicker label="Pick a date" defaultValue="2023-06-25" />
+    </CunninghamProvider>
+  </div>
+);
+
 export const Controlled = () => {
   const [value, setValue] = useState<StringOrDate | null>("2023-05-26");
   return (

--- a/packages/react/src/components/Provider/index.spec.tsx
+++ b/packages/react/src/components/Provider/index.spec.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import React, { PropsWithChildren, useMemo, useState } from "react";
 import userEvent from "@testing-library/user-event";
-import { CunninghamProvider, useCunningham } from ":/components/Provider/index";
+import { expect } from "vitest";
+import {
+  CunninghamProvider,
+  DEFAULT_LOCALE,
+  useCunningham,
+} from ":/components/Provider/index";
 import * as enUS from ":/locales/en-US.json";
 import { Button } from ":/components/Button";
 
@@ -101,5 +106,51 @@ describe("<CunninghamProvider />", () => {
       level: 1,
       name: "components.will_never_exist",
     });
+  });
+
+  it("should return current locale", () => {
+    const locale = "fr-FR";
+    const Wrapper = (props: PropsWithChildren) => {
+      return (
+        <CunninghamProvider currentLocale={locale}>
+          {props.children}
+        </CunninghamProvider>
+      );
+    };
+    const Wrapped = () => {
+      const { currentLocale } = useCunningham();
+      expect(currentLocale).eq(locale);
+      return <div />;
+    };
+    render(<Wrapped />, { wrapper: Wrapper });
+  });
+
+  it("should return default locale if no current locale is provided", () => {
+    const Wrapper = (props: PropsWithChildren) => {
+      return <CunninghamProvider>{props.children}</CunninghamProvider>;
+    };
+    const Wrapped = () => {
+      const { currentLocale } = useCunningham();
+      expect(currentLocale).eq(DEFAULT_LOCALE);
+      return <div />;
+    };
+    render(<Wrapped />, { wrapper: Wrapper });
+  });
+
+  it("should return default locale if the current locale is not supported", () => {
+    const wrongLocale = "fr_FR";
+    const Wrapper = (props: PropsWithChildren) => {
+      return (
+        <CunninghamProvider currentLocale={wrongLocale}>
+          {props.children}
+        </CunninghamProvider>
+      );
+    };
+    const Wrapped = () => {
+      const { currentLocale } = useCunningham();
+      expect(currentLocale).eq(DEFAULT_LOCALE);
+      return <div />;
+    };
+    render(<Wrapped />, { wrapper: Wrapper });
   });
 });

--- a/packages/react/src/components/Provider/index.tsx
+++ b/packages/react/src/components/Provider/index.tsx
@@ -15,6 +15,7 @@ const CunninghamContext = createContext<
   | undefined
   | {
       t: (key: string, vars?: Record<string, string | number>) => string;
+      currentLocale: string;
     }
 >(undefined);
 
@@ -57,17 +58,14 @@ export const CunninghamProvider = ({
   );
 
   const locale = useMemo(() => {
-    if (!locales[currentLocale]) {
-      return locales[DEFAULT_LOCALE];
-    }
-    return locales[currentLocale];
+    return (locales[currentLocale] && currentLocale) || DEFAULT_LOCALE;
   }, [currentLocale, locales]);
 
   const context = useMemo(
     () => ({
       t: (key: string, vars?: Record<string, string | number>) => {
         let message: string =
-          findTranslation(key, locale) ??
+          findTranslation(key, locales[locale]) ??
           findTranslation(key, locales[DEFAULT_LOCALE]) ??
           key;
 
@@ -80,6 +78,7 @@ export const CunninghamProvider = ({
 
         return message;
       },
+      currentLocale: locale,
     }),
     [currentLocale, locales]
   );


### PR DESCRIPTION
## Purpose
Improve international capabilities of the `DatePicker` component using a`locale` props or the Cunningham provider. Dates would be automatically displayed in the appropriate calendar system.

## Proposal

- [x] Expose `currentLocale` value in the `CunninghamContext`.
- [x] By default, synchronize `DatePicker`'s calendar system with `currentLocale` value.
- [x] Add `locale` props to the `DatePicker`component that overrides `currentLocale` value.
- [x] Automatically update calendar system in the `DatePicker` component using the `I18nProvider`.
- [x] Add tests on the `DatePicker` component.
- [x] Add tests on the `CunninghamProvider`

## To be discussed
with @jbpenrath 

- [x] Timezone.
- [x] Locale values (corner cases).
- [x] `CunninghamProvider` current modifications and potential refactoring.

