### PR TITLE
🐛(react) avoid storybook errors

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -8,6 +8,6 @@
     "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src", "cunningham.ts"],
-  "exclude": ["node_modules","dist", "**/tokens.ts"],
+  "exclude": ["node_modules","dist", "**/tokens.ts", "**/*.stories.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Since our upgrade from Typescript 5.0.4 to 5.1.3 some errors started to occur when running yarn build in .stories.tsx files. Please see the related issue: https://github.com/storybookjs/storybook/issues/23249. Adding this ignore clause partitions the storybook compilation and the package compilation which represents how things really work together, thus making the irrelevant errors to be removed.