### PR TITLE
🐛(react) resolve development warning in `CalendarAux` component

### DIFF
--- a/.changeset/pretty-radios-eat.md
+++ b/.changeset/pretty-radios-eat.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+Fixed development warning in `CalendarAux` component

--- a/packages/react/src/components/Forms/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/Forms/DatePicker/Calendar.tsx
@@ -174,16 +174,18 @@ const CalendarAux = forwardRef(
     const downshiftMonth = useDownshiftSelect("month", monthItems);
     const downshiftYear = useDownshiftSelect("year", yearItems);
 
-    // isDisabled and onPress props don't exist on the <Button /> component.
+    // isDisabled, onPress and onFocusChange props don't exist on the <Button /> component.
     // remove them to avoid any warning.
     const {
       isDisabled: isPrevButtonDisabled,
       onPress: onPressPrev,
+      onFocusChange: onFocusChangePrev,
       ...prevButtonOtherProps
     } = prevButtonProps;
     const {
       isDisabled: isNextButtonDisabled,
       onPress: onPressNext,
+      onFocusChange: onFocusChangeNext,
       ...nextButtonOtherProps
     } = nextButtonProps;
 


### PR DESCRIPTION
Resolve development warning in `CalendarAux` component caused by recent updates to react-aria dependencies. Update props for next and previous calendar buttons, removing `onFocusChange` before passing to the Button component.