### PR TITLE
🐛(react) fix unexisting import

### DIFF
--- a/.changeset/chilled-brooms-leave.md
+++ b/.changeset/chilled-brooms-leave.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+fix RadioGroup optional prop

--- a/.changeset/purple-jars-turn.md
+++ b/.changeset/purple-jars-turn.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+bug fix, remove usage of InputRefType

--- a/packages/react/build
+++ b/packages/react/build
@@ -1,7 +1,7 @@
 #!/bin/bash
-tsc
-yarn build-theme
-vite build
-yarn build-fonts
-yarn build-icons
-cp -R src/locales dist/
+tsc \
+&& yarn build-theme \
+&& vite build \
+&& yarn build-fonts \
+&& yarn build-icons \
+&& cp -R src/locales dist/

--- a/packages/react/src/components/Forms/FileUploader/index.tsx
+++ b/packages/react/src/components/Forms/FileUploader/index.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, InputHTMLAttributes, ReactElement } from "react";
 import { Field, FieldProps, FieldState } from ":/components/Forms/Field";
-import { InputRefType } from ":/components/Forms/Input";
 import { FileUploaderMulti } from ":/components/Forms/FileUploader/FileUploaderMulti";
 import { FileUploaderMono } from ":/components/Forms/FileUploader/FileUploaderMono";
 
@@ -22,7 +21,7 @@ export interface FileUploaderProps
   fakeDefaultFiles?: File[];
 }
 
-export interface FileUploaderRefType extends InputRefType {
+export interface FileUploaderRefType {
   reset: () => void;
 }
 

--- a/packages/react/src/components/Forms/Input/index.spec.tsx
+++ b/packages/react/src/components/Forms/Input/index.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import React, { useRef } from "react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "vitest";
-import { Input, InputRefType } from ":/components/Forms/Input/index";
+import { Input } from ":/components/Forms/Input/index";
 import { Button } from ":/components/Button";
 
 describe("<Input/>", () => {
@@ -146,11 +146,11 @@ describe("<Input/>", () => {
   it("forwards ref", async () => {
     const user = userEvent.setup();
     const Wrapper = () => {
-      const ref = useRef<InputRefType>(null);
+      const ref = useRef<HTMLInputElement>(null);
       return (
         <div>
           <Input label="First name" ref={ref} />
-          <Button onClick={() => ref.current?.input?.focus()}>Focus</Button>
+          <Button onClick={() => ref.current?.focus()}>Focus</Button>
         </div>
       );
     };

--- a/packages/react/src/components/Forms/Input/index.stories.tsx
+++ b/packages/react/src/components/Forms/Input/index.stories.tsx
@@ -3,7 +3,7 @@ import { Meta } from "@storybook/react";
 import { useForm } from "react-hook-form";
 import * as Yup from "yup";
 import React, { useRef } from "react";
-import { Input, InputRefType } from ":/components/Forms/Input/index";
+import { Input } from ":/components/Forms/Input/index";
 import { Button } from ":/components/Button";
 import {
   getFieldState,
@@ -166,7 +166,7 @@ export const NonControlled = () => {
 };
 
 export const WithRef = () => {
-  const ref = useRef<InputRefType>(null);
+  const ref = useRef<HTMLInputElement>(null);
   return (
     <div>
       <Input label="Your identity" ref={ref} />

--- a/packages/react/src/components/Forms/Radio/index.tsx
+++ b/packages/react/src/components/Forms/Radio/index.tsx
@@ -36,7 +36,7 @@ export const RadioGroup = ({
   text,
   rightText,
   style,
-}: PropsWithChildren & FieldProps & { style: React.CSSProperties }) => {
+}: PropsWithChildren & FieldProps & { style?: React.CSSProperties }) => {
   return (
     <Field
       className="c__radio__group c__checkbox__group"


### PR DESCRIPTION
Since b72d0d5c9098e69cc670c9cc3282f2d4d0be01a9 InputRefType doesn't exist.
We missed some usage of it that are removed in this fix.