### PR TITLE
Release/fix/react

### DIFF
--- a/.changeset/chilled-brooms-leave.md
+++ b/.changeset/chilled-brooms-leave.md
@@ -1,5 +1,0 @@
----
-"@openfun/cunningham-react": minor
----
-
-fix RadioGroup optional prop

--- a/.changeset/purple-jars-turn.md
+++ b/.changeset/purple-jars-turn.md
@@ -1,5 +1,0 @@
----
-"@openfun/cunningham-react": minor
----
-
-bug fix, remove usage of InputRefType

--- a/.changeset/yellow-meals-mix.md
+++ b/.changeset/yellow-meals-mix.md
@@ -1,5 +1,0 @@
----
-"@openfun/cunningham-tokens": patch
----
-
-Fix bug on sass token generation

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfun/cunningham-react
 
+## 0.11.1
+
+### Patch Changes
+
+- 4eae45c: fix RadioGroup optional prop
+- 3e1cdbe: bug fix, remove usage of InputRefType
+
 ## 0.11.0
 
 ### Minor Changes
@@ -180,8 +187,9 @@
 - 4ebbf16: Add package
 - 4ebbf16: Add component's tokens handling
 
-[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.11.0...main
-[0.10.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.10.0...@openfun/cunningham-react@0.11.0
+[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.11.1...main
+[0.11.1]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.11.0...@openfun/cunningham-react@0.11.1
+[0.11.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.10.0...@openfun/cunningham-react@0.11.0
 [0.10.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.9.0...@openfun/cunningham-react@0.10.0
 [0.9.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.8.2...@openfun/cunningham-react@0.9.0
 [0.8.2]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@0.8.1...@openfun/cunningham-react@0.8.2

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfun/cunningham-react",
   "private": false,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfun/cunningham-tokens
 
+## 0.7.1
+
+### Patch Changes
+
+- 7de28bc: Fix bug on sass token generation
+
 ## 0.7.0
 
 ### Minor Changes
@@ -57,7 +63,8 @@
 - 4ebbf16: Add utility classes
 - 4ebbf16: Add official design tokens
 
-[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-tokens@0.7.0...main
+[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-tokens@0.7.1...main
+[0.7.1]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-tokens@0.7.0...@openfun/cunningham-tokens@0.7.1
 [0.7.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-tokens@0.6.0...@openfun/cunningham-tokens@0.7.0
 [0.6.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-tokens@0.5.0...@openfun/cunningham-tokens@0.6.0
 [0.5.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-tokens@0.4.0...@openfun/cunningham-tokens@0.5.0

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfun/cunningham-tokens",
   "private": false,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fix release of `tokens` and `react` packages

## @openfun/cunningham-tokens 0.7.1

### Patch Changes

- 7de28bc: Fix bug on sass token generation

## @openfun/cunningham-react 0.11.1

### Patch Changes

- 4eae45c: fix RadioGroup optional prop
- 3e1cdbe: bug fix, remove usage of InputRefType