### PR TITLE
🏷️(react) export more types

### DIFF
--- a/.changeset/yellow-rules-repeat.md
+++ b/.changeset/yellow-rules-repeat.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+export more types

--- a/packages/react/src/components/Forms/Checkbox/index.tsx
+++ b/packages/react/src/components/Forms/Checkbox/index.tsx
@@ -9,13 +9,13 @@ import React, {
 import classNames from "classnames";
 import { Field, FieldProps } from ":/components/Forms/Field";
 
-type Props = InputHTMLAttributes<HTMLInputElement> &
+export type CheckboxProps = InputHTMLAttributes<HTMLInputElement> &
   FieldProps & {
     indeterminate?: boolean;
     label?: string;
   };
 
-export const Checkbox = forwardRef<HTMLInputElement, Props>(
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
     {
       indeterminate,
@@ -26,7 +26,7 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
       rightText,
       state,
       ...props
-    }: Props,
+    }: CheckboxProps,
     ref,
   ) => {
     const inputRef = useRef<HTMLInputElement>();

--- a/packages/react/src/components/Forms/Input/index.tsx
+++ b/packages/react/src/components/Forms/Input/index.tsx
@@ -11,7 +11,7 @@ import { randomString } from ":/utils";
 import { Field, FieldProps } from ":/components/Forms/Field";
 import { LabelledBox } from ":/components/Forms/LabelledBox";
 
-type Props = InputHTMLAttributes<HTMLInputElement> &
+export type InputProps = InputHTMLAttributes<HTMLInputElement> &
   FieldProps & {
     label?: string;
     icon?: ReactNode;
@@ -20,7 +20,7 @@ type Props = InputHTMLAttributes<HTMLInputElement> &
     charCounterMax?: number;
   };
 
-export const Input = forwardRef<HTMLInputElement, Props>(
+export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       className,
@@ -36,7 +36,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       charCounter,
       charCounterMax,
       ...props
-    }: Props,
+    }: InputProps,
     ref,
   ) => {
     const classes = ["c__input"];

--- a/packages/react/src/components/Forms/Radio/index.tsx
+++ b/packages/react/src/components/Forms/Radio/index.tsx
@@ -6,13 +6,13 @@ import React, {
 import classNames from "classnames";
 import { Field, FieldProps } from ":/components/Forms/Field";
 
-type Props = InputHTMLAttributes<HTMLInputElement> &
+export type RadioProps = InputHTMLAttributes<HTMLInputElement> &
   FieldProps & {
     label?: string;
   };
 
-export const Radio = forwardRef<HTMLInputElement, Props>(
-  ({ label, text, state, ...props }: Props, ref) => {
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  ({ label, text, state, ...props }: RadioProps, ref) => {
     return (
       <label
         className={classNames("c__checkbox", "c__radio", {

--- a/packages/react/src/components/Forms/Select/index.tsx
+++ b/packages/react/src/components/Forms/Select/index.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { SelectMulti } from ":/components/Forms/Select/multi";
 import { SelectMono, SelectProps } from ":/components/Forms/Select/mono";
 
+export * from ":/components/Forms/Select/mono";
+export * from ":/components/Forms/Select/multi";
+
 export const Select = (props: SelectProps) => {
   if (props.defaultValue && props.value) {
     throw new Error(

--- a/packages/react/src/components/Forms/Switch/index.tsx
+++ b/packages/react/src/components/Forms/Switch/index.tsx
@@ -2,15 +2,22 @@ import React, { InputHTMLAttributes, forwardRef } from "react";
 import classNames from "classnames";
 import { Field, FieldProps } from ":/components/Forms/Field";
 
-type Props = InputHTMLAttributes<HTMLInputElement> &
+export type SwitchProps = InputHTMLAttributes<HTMLInputElement> &
   FieldProps & {
     label?: string;
     labelSide?: "left" | "right";
   };
 
-export const Switch = forwardRef<HTMLInputElement, Props>(
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
   (
-    { label, text, state, fullWidth, labelSide = "left", ...props }: Props,
+    {
+      label,
+      text,
+      state,
+      fullWidth,
+      labelSide = "left",
+      ...props
+    }: SwitchProps,
     ref,
   ) => {
     return (


### PR DESCRIPTION
Based on recent developers feedbacks that needed to use props types in order to wrap the lib's component they were stuck because we were not exporting all of them.
