### PR TITLE
♻️(react) improve select element keys

### DIFF
--- a/.changeset/sweet-rats-poke.md
+++ b/.changeset/sweet-rats-poke.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+fix failing selection of last removed item

--- a/packages/react/src/components/Forms/Select/mono-common.tsx
+++ b/packages/react/src/components/Forms/Select/mono-common.tsx
@@ -175,7 +175,7 @@ export const SelectMonoAux = ({
                           downshiftReturn.selectedItem === item,
                         "c__select__menu__item--disabled": item.disabled,
                       })}
-                      key={`${item.value}${index.toString()}`}
+                      key={`${optionToValue(item)}${index.toString()}`}
                       {...downshiftReturn.getItemProps({
                         item,
                         index,

--- a/packages/react/src/components/Forms/Select/multi-common.tsx
+++ b/packages/react/src/components/Forms/Select/multi-common.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes } from "react";
 import { useMultipleSelection } from "downshift";
 import classNames from "classnames";
-
 import { Field } from ":/components/Forms/Field";
 import { LabelledBox } from ":/components/Forms/LabelledBox";
 import { Button } from ":/components/Button";
@@ -96,7 +95,7 @@ export const SelectMultiAux = ({
         >
           {selectedItems.map((selectedItem, index) => (
             <input
-              key={`${selectedItem.value}${index}`}
+              key={`${optionToValue(selectedItem)}${index.toString()}`}
               type="hidden"
               name={name}
               value={optionToValue(selectedItem)}
@@ -152,7 +151,9 @@ export const SelectMultiAux = ({
                   return (
                     <div
                       className="c__select__inner__value__pill"
-                      key={`${selectedItemForRender.value}${index}`}
+                      key={`${optionToValue(
+                        selectedItemForRender,
+                      )}${index.toString()}`}
                       {...useMultipleSelectionReturn.getSelectedItemProps({
                         selectedItem: selectedItemForRender,
                         index,
@@ -201,7 +202,7 @@ export const SelectMultiAux = ({
                         "c__select__menu__item--highlight": isActive,
                         "c__select__menu__item--disabled": option.disabled,
                       })}
-                      key={`${option.value}${index.toString()}`}
+                      key={`${optionToValue(option)}${index.toString()}`}
                       {...downshiftReturn.getItemProps({
                         item: option,
                         index,

--- a/packages/react/src/components/Forms/Select/multi-searchable.tsx
+++ b/packages/react/src/components/Forms/Select/multi-searchable.tsx
@@ -37,7 +37,7 @@ export const SelectMultiSearchable = (props: SubProps) => {
     items: options,
     itemToString: optionToString,
     defaultHighlightedIndex: 0, // after selection, highlight the first item.
-    selectedItem: null,
+    selectedItem: null, // Important, without this we are not able to re-select the last removed option.
     stateReducer: (state, actionAndChanges) => {
       const { changes, type } = actionAndChanges;
       switch (type) {

--- a/packages/react/src/components/Forms/Select/multi-simple.tsx
+++ b/packages/react/src/components/Forms/Select/multi-simple.tsx
@@ -32,6 +32,7 @@ export const SelectMultiSimple = (props: SubProps) => {
   const downshiftReturn = useSelect({
     items: options,
     itemToString: optionToString,
+    selectedItem: null, // Important, without this we are not able to re-select the last removed option.
     defaultHighlightedIndex: 0, // after selection, highlight the first item.
     stateReducer: (state, actionAndChanges) => {
       const { changes, type } = actionAndChanges;

--- a/packages/react/src/components/Forms/Select/multi-simple.tsx
+++ b/packages/react/src/components/Forms/Select/multi-simple.tsx
@@ -52,7 +52,6 @@ export const SelectMultiSimple = (props: SubProps) => {
         case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
         case useSelect.stateChangeTypes.ToggleButtonKeyDownSpaceButton:
         case useSelect.stateChangeTypes.ItemClick:
-        case useSelect.stateChangeTypes.ToggleButtonBlur:
           if (newSelectedItem) {
             props.onSelectedItemsChange([
               ...props.selectedItems,

--- a/packages/react/src/components/Forms/Select/multi.spec.tsx
+++ b/packages/react/src/components/Forms/Select/multi.spec.tsx
@@ -724,6 +724,67 @@ describe("<Select multi={true} />", () => {
       const label = screen.getByText("Cities");
       expect(Array.from(label.classList)).toContain("offscreen");
     });
+
+    it("is possible to select again the last deleted item", async () => {
+      render(
+        <CunninghamProvider>
+          <Select
+            label="Cities"
+            options={[
+              {
+                label: "Paris",
+                value: "paris",
+              },
+              {
+                label: "London",
+                value: "london",
+              },
+              {
+                label: "New York",
+                value: "new_york",
+              },
+              {
+                label: "Tokyo",
+                value: "tokyo",
+              },
+            ]}
+            multi={true}
+          />
+        </CunninghamProvider>,
+      );
+
+      const input = screen.getByRole("combobox", {
+        name: "Cities",
+      });
+      expectSelectedOptions([]);
+
+      const user = userEvent.setup();
+      await user.click(input);
+
+      // Select options.
+      await user.click(
+        screen.getByRole("option", {
+          name: "Paris",
+        }),
+      );
+      expectSelectedOptions(["Paris"]);
+
+      // Clear selection.
+      const clearButton = screen.getByRole("button", {
+        name: "Clear all selections",
+      });
+      await user.click(clearButton);
+      expectSelectedOptions([]);
+
+      // Select again London.
+      await user.click(input);
+      await user.click(
+        screen.getByRole("option", {
+          name: "Paris",
+        }),
+      );
+      expectSelectedOptions(["Paris"]);
+    });
   });
 
   describe("Searchable", async () => {


### PR DESCRIPTION
It was considered as a bad practice to include array indexes in list elements keys even though it was made this way in the documentation. We removed them and also decided to drop the use of options value in the keys too to the profit of optionToValue which can never be undefined or null. This changes caused test crashing due to the fact that it made the useSelect onStateChange trigger a onBlur event that was causing the first option of the list to be selected automatically, which was a really weird behavior. Before it was not happening because newSelectedItem was not defined, using the new keys made it defined, we don't 100% understand why yet.