### PR TITLE
🐛(react) fix select pills submiting form

### DIFF
--- a/packages/react/src/components/Forms/Select/multi-common.tsx
+++ b/packages/react/src/components/Forms/Select/multi-common.tsx
@@ -168,6 +168,7 @@ export const SelectMultiAux = ({
                         aria-label={t(
                           "components.forms.select.clear_button_aria_label",
                         )}
+                        type="button"
                         className="c__select__inner__value__pill__clear"
                         onClick={(e) => {
                           e.stopPropagation();


### PR DESCRIPTION
We found out that clicking on the delete button of the pill in example forms were triggering form submit.