### PR TITLE
🐛 Fix select searchable edge cases

### DIFF
--- a/.changeset/tall-bats-wink.md
+++ b/.changeset/tall-bats-wink.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+fix some edge effects on the mono select component

--- a/packages/react/src/components/Forms/Select/mono-simple.tsx
+++ b/packages/react/src/components/Forms/Select/mono-simple.tsx
@@ -16,14 +16,21 @@ export const SelectMonoSimple = (props: SubProps) => {
 
   // When component is controlled, this useEffect will update the local selected item.
   useEffect(() => {
-    if (props.downshiftProps.initialSelectedItem !== undefined) {
-      return;
-    }
+    const selectedItem = downshiftReturn.selectedItem
+      ? optionToValue(downshiftReturn.selectedItem)
+      : undefined;
+
     const optionToSelect = props.options.find(
       (option) => optionToValue(option) === props.value,
     );
+
+    // Already selected
+    if (optionToSelect && selectedItem === props.value) {
+      return;
+    }
+
     downshiftReturn.selectItem(optionToSelect ?? null);
-  }, [props.value, props.options, props.downshiftProps]);
+  }, [props.value, props.options]);
 
   return (
     <SelectMonoAux

--- a/packages/react/src/components/Forms/Select/mono.tsx
+++ b/packages/react/src/components/Forms/Select/mono.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useEffect, useState } from "react";
 import { UseSelectStateChange } from "downshift";
 import { FieldProps } from ":/components/Forms/Field";
 import { optionToValue, SubProps } from ":/components/Forms/Select/mono-common";
@@ -37,17 +37,32 @@ export const SelectMono = (props: SelectProps) => {
         (option) => optionToValue(option) === props.defaultValue,
       )
     : undefined;
+  const [value, setValue] = useState(
+    defaultSelectedItem ? optionToValue(defaultSelectedItem) : props.value,
+  );
+
+  /**
+   * This useEffect is used to update the local value when the component is controlled.
+   * The defaultValue is used only on first render.
+   */
+  useEffect(() => {
+    if (props.defaultValue) {
+      return;
+    }
+    setValue(props.value);
+  }, [props.value, props.defaultValue]);
 
   const commonDownshiftProps: SubProps["downshiftProps"] = {
     initialSelectedItem: defaultSelectedItem,
     onSelectedItemChange: (e: UseSelectStateChange<Option>) => {
       const eventCmp = e.selectedItem ? optionToValue(e.selectedItem) : null;
-      const valueCmp = props.value ?? null;
+      const valueCmp = value ?? null;
       // We make sure to not trigger a onChange event if the value are not different.
       // This could happen on first render when the component is controlled, the value will be
       // set inside a useEffect down in SelectMonoSearchable or SelectMonoSimple. So that means the
       // downshift component will always render empty the first time.
       if (eventCmp !== valueCmp) {
+        setValue(eventCmp || undefined);
         props.onChange?.({
           target: {
             value: e.selectedItem ? optionToValue(e.selectedItem) : undefined,
@@ -59,8 +74,16 @@ export const SelectMono = (props: SelectProps) => {
   };
 
   return props.searchable ? (
-    <SelectMonoSearchable {...props} downshiftProps={commonDownshiftProps} />
+    <SelectMonoSearchable
+      {...props}
+      downshiftProps={commonDownshiftProps}
+      value={value}
+    />
   ) : (
-    <SelectMonoSimple {...props} downshiftProps={commonDownshiftProps} />
+    <SelectMonoSimple
+      {...props}
+      downshiftProps={commonDownshiftProps}
+      value={value}
+    />
   );
 };


### PR DESCRIPTION
## Purpose

When the select is opened and the options change, the user could click on a option not existing anymore.

[scrnli_9_22_2023_1-27-08 PM.webm](https://github.com/openfun/cunningham/assets/25994652/ecdefb44-2d0f-4805-bce5-a9c18700f3c8)

## Proposal

- [x] refresh the options when the select is opened to avoid to click on a inexistent option
- [x] keep the filter if the user started to do some filtering
- [x] test

[scrnli_9_22_2023_1-35-09 PM.webm](https://github.com/openfun/cunningham/assets/25994652/a226f282-b9c5-41a9-a79b-7c238d7074f1)
