### PR TITLE
🩹(react) export Popover component and its props

### DIFF
--- a/.changeset/few-bats-stare.md
+++ b/.changeset/few-bats-stare.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+Inlcude Popover component to package exports

--- a/packages/react/src/components/Popover/index.tsx
+++ b/packages/react/src/components/Popover/index.tsx
@@ -8,7 +8,7 @@ import React, {
 import classNames from "classnames";
 import { useHandleClickOutside } from ":/hooks/useHandleClickOutside";
 
-type PopoverProps = PropsWithChildren & {
+export type PopoverProps = PropsWithChildren & {
   parentRef: RefObject<HTMLDivElement>;
   onClickOutside: () => void;
   borderless?: boolean;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,18 +4,19 @@ import { tokens } from "./cunningham-tokens";
 
 export * from "./components/Button";
 export * from "./components/DataGrid";
+export * from "./components/DataGrid/DataList";
 export * from "./components/DataGrid/SimpleDataGrid";
 export * from "./components/Forms/Checkbox";
-export * from "./components/DataGrid/DataList";
+export * from "./components/Forms/DatePicker";
 export * from "./components/Forms/Field";
 export * from "./components/Forms/FileUploader";
 export * from "./components/Forms/Input";
 export * from "./components/Forms/Radio";
 export * from "./components/Forms/Select";
 export * from "./components/Forms/Switch";
-export * from "./components/Forms/DatePicker";
 export * from "./components/Loader";
 export * from "./components/Pagination";
+export * from "./components/Popover";
 export * from "./components/Provider";
 
 export type DefaultTokens = PartialNested<typeof tokens>;


### PR DESCRIPTION
Include missing Popover component exports to the React package.
Re-order package exports to be alphabetically sorted.

It closes #176.