### PR TITLE
🩹(react) export Button props

### DIFF
--- a/.changeset/tough-toys-obey.md
+++ b/.changeset/tough-toys-obey.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+Export Button props

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import React, { ButtonHTMLAttributes, forwardRef, ReactNode } from "react";
 
-interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   color?: "primary" | "secondary" | "tertiary" | "danger";
   size?: "medium" | "small" | "nano";
   icon?: ReactNode;
@@ -9,7 +9,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   fullWidth?: boolean;
 }
 
-export const Button = forwardRef<HTMLButtonElement, Props>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       children,


### PR DESCRIPTION
## Purpose

In some cases we need the props of a component to be exported, to be able to use them in other components.

In our case, `styled-component` needs the Button props type to be able to extend it.

![image](https://github.com/openfun/cunningham/assets/25994652/81cfa41d-63ab-4bf0-9ad6-db12df35df9b)
 