### PR TITLE
🚨(build) fix Vite CJS config warning

### DIFF
--- a/packages/react/tsconfig.node.json
+++ b/packages/react/tsconfig.node.json
@@ -5,5 +5,7 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.mts"
+  ]
 }

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -1,9 +1,8 @@
 import { resolve } from "path";
-import { defineConfig } from "vitest/config";
+import { defineConfig, BuildOptions } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { BuildOptions } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
Since the migration to Vite 5 we had the "The CJS build of Vite's Node API is deprecated" error ocurring during compilation.

We needed to rename to .mts the vite config file in order for it to acknowledge that we are using the Node ESM API, this is needed because we do not set "type": "module" in package.json because we need to support CJS too.