### PR TITLE
🐛(react) fix TextArea value color

### DIFF
--- a/packages/react/src/components/Forms/TextArea/index.scss
+++ b/packages/react/src/components/Forms/TextArea/index.scss
@@ -29,6 +29,7 @@
     padding: 0 1rem;
     box-sizing: border-box;
     font-family: var(--c--theme--font--families--base);
+    color: var(--c--components--forms-textarea--value-color);
 
     &:focus-visible {
       outline: none;


### PR DESCRIPTION
The dedicated token was not used, so here it is.

Fixes #230

# Before 
<img width="481" alt="Capture d’écran 2024-01-16 à 16 12 42" src="https://github.com/openfun/cunningham/assets/9628870/e6b65e7a-1843-44fa-aaba-a51c699790fd">

# After
<img width="368" alt="Capture d’écran 2024-01-16 à 16 12 36" src="https://github.com/openfun/cunningham/assets/9628870/d5bf535c-a456-4d96-809f-b4c298b41479">
