### PR TITLE
🔧(git) add .turbo folder to .gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist
 
 vite.config.ts.timestamp-*
 env.d
+.turbo


### PR DESCRIPTION
Ignore this cache folder that must only be stored locally.