### PR TITLE
🐛(react) fix DatePicker dropdowns + ♻️(react) remove disabled from getItemProps

### DIFF
--- a/.changeset/angry-penguins-kneel.md
+++ b/.changeset/angry-penguins-kneel.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+fix DatePicker dropdowns closing

--- a/packages/react/src/components/Forms/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/Forms/DatePicker/Calendar.tsx
@@ -67,7 +67,6 @@ const DropdownValues = ({ options, downShift }: DropdownValuesProps) => (
             {...downShift.getItemProps({
               item,
               index,
-              disabled: item.disabled,
             })}
             className={classNames("c__calendar__menu__item", {
               "c__calendar__menu__item--highlight":

--- a/packages/react/src/components/Forms/DatePicker/DateRangePicker.spec.tsx
+++ b/packages/react/src/components/Forms/DatePicker/DateRangePicker.spec.tsx
@@ -538,6 +538,60 @@ describe("<DateRangePicker/>", () => {
     expectDatesToBeEqual(endDate, endInput.textContent);
   });
 
+  it("picks a date range spanning multiple years using dropdown", async () => {
+    const user = userEvent.setup();
+    render(
+      <CunninghamProvider>
+        <DateRangePicker
+          startLabel="Start date"
+          endLabel="End date"
+          name="datepicker"
+        />
+      </CunninghamProvider>,
+    );
+    const [input] = await screen.findAllByRole("button");
+    await user.click(input);
+    expectCalendarToBeOpen();
+
+    // Select the start date.
+    const yearButton = screen.getByRole("combobox", {
+      name: "Select a year",
+    });
+    await user.click(yearButton);
+    await user.click(screen.getByRole("option", { name: "1910" }));
+
+    const monthButton = screen.getByRole("combobox", {
+      name: "Select a month",
+    });
+    await user.click(monthButton);
+    await user.click(screen.getByRole("option", { name: "January" }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Saturday, January 1, 1910",
+      }),
+    );
+
+    // Select the end date.
+    await user.click(yearButton);
+    await user.click(screen.getByRole("option", { name: "2040" }));
+    await user.click(monthButton);
+    await user.click(screen.getByRole("option", { name: "September" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Sunday, September 2, 2040",
+      }),
+    );
+
+    // Make sure the correct dates are set.
+    expectCalendarToBeClosed();
+    const startDate = "Saturday, January 1, 1910";
+    const endDate = "Sunday, September 2, 2040";
+    const [startInput, endInput] = await screen.queryAllByRole("presentation");
+    expectDatesToBeEqual(startDate, startInput.textContent);
+    expectDatesToBeEqual(endDate, endInput.textContent);
+  });
+
   it("types a date range", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
When having a start date, using the year or month dropdown was causing the calendar to abruptly close.

Removing disabled to getItemProps call: this was triggering thousands of warnings in the console and during tests. Removing it works because it seems that having item.disabled set allows to not having to use isItemDisabled.