### PR TITLE
♻️(react) use info design tokens

### DIFF
--- a/.changeset/gorgeous-sloths-compete.md
+++ b/.changeset/gorgeous-sloths-compete.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+use info design tokens

--- a/packages/react/src/components/Alert/_index.scss
+++ b/packages/react/src/components/Alert/_index.scss
@@ -65,11 +65,11 @@
   }
 
   &--info {
-    border-color: var(--c--theme--colors--primary-300);
-    border-left-color: var(--c--theme--colors--primary-600);
+    border-color: var(--c--theme--colors--info-300);
+    border-left-color: var(--c--theme--colors--info-600);
 
     .c__alert__icon {
-      color: var(--c--theme--colors--primary-600);
+      color: var(--c--theme--colors--info-600);
     }
   }
 

--- a/packages/react/src/components/Toast/index.scss
+++ b/packages/react/src/components/Toast/index.scss
@@ -79,11 +79,11 @@
 
   &--info {
     .c__progress-bar {
-      --c--progress--color: var(--c--theme--colors--primary-500);
+      --c--progress--color: var(--c--theme--colors--info-500);
     }
 
     .c__toast__icon {
-      color: var(--c--theme--colors--primary-600);
+      color: var(--c--theme--colors--info-600);
     }
   }
 


### PR DESCRIPTION
Some info variant of components were using primary design token instead of info.