### PR TITLE
👷(ci) put storybook build in a gh-pages sub folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,9 @@ jobs:
       - run:
           name: Publish storybook
           command: |
-            cd packages/react
             git config user.email "funmoocbot@users.noreply.github.com"
             git config user.name "FUN MOOC bot"
-            yarn deploy-storybook
+            yarn deploy-ghpages
   publish-packages:
     docker:
       - image: cimg/node:18.18

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist
 vite.config.ts.timestamp-*
 env.d
 .turbo
+ghpages-output

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **A design system and a components library.**
 
-<a href="https://openfun.github.io/cunningham"><b>📚&nbsp;&nbsp;Documentation</b></a> •
+<a href="https://openfun.github.io/cunningham/storybook"><b>📚&nbsp;&nbsp;Documentation</b></a> •
 <a href="https://www.figma.com/file/JbPT1R6YUFW4oH8jHvH960/DS-Cunningham---PUBLIC?type=design"><b>🖌️&nbsp;&nbsp;Figma</b></a>
 
 </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test-ci": "turbo run test-ci",
     "lint": "turbo run lint",
     "deploy": "turbo run deploy",
-    "format": "prettier --write \"**/*.{ts,tsx,md,json,cjs,js}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md,json,cjs,js}\"",
+    "predeploy-ghpages": "./scripts/predeploy-ghpages",
+    "deploy-ghpages": "storybook-to-ghpages --existing-output-dir ./ghpages-output"
   },
   "devDependencies": {
     "cross-env": "7.0.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,9 +39,7 @@
     "test-watch": "vitest",
     "coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
-    "predeploy-storybook": "yarn build-storybook && touch ./storybook-static/.nojekyll",
-    "deploy-storybook": "storybook-to-ghpages --existing-output-dir ./storybook-static"
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@fontsource-variable/roboto-flex": "5.0.8",

--- a/scripts/predeploy-ghpages
+++ b/scripts/predeploy-ghpages
@@ -1,0 +1,9 @@
+rm -rf ghpages-output
+mkdir -p ghpages-output/storybook
+
+cd packages/react && yarn build-storybook
+cd ../..
+mv packages/react/storybook-static/* ghpages-output/storybook
+
+touch ./ghpages-output/.nojekyll
+touch ./ghpages-output/storybook/.nojekyll


### PR DESCRIPTION
Our main goal doing this is to allow us to have multiple static build
standing next to each other on our gh-pages.