### PR TITLE
👷(ci) deploy demo app on gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 **A design system and a components library.**
 
 <a href="https://openfun.github.io/cunningham/storybook"><b>📚&nbsp;&nbsp;Documentation</b></a> •
-<a href="https://www.figma.com/file/JbPT1R6YUFW4oH8jHvH960/DS-Cunningham---PUBLIC?type=design"><b>🖌️&nbsp;&nbsp;Figma</b></a>
+<a href="https://www.figma.com/file/JbPT1R6YUFW4oH8jHvH960/DS-Cunningham---PUBLIC?type=design"><b>🖌️&nbsp;&nbsp;Figma</b></a> •
+<a href="https://openfun.github.io/cunningham/demo"><b>🕹️&nbsp;&nbsp;Demo</b></a>
 
 </div>
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -8,6 +8,7 @@
     "dev": "vite & nodemon --watch cunningham.ts --exec yarn build-theme",
     "build-theme": "cunningham -o src -g css,ts",
     "build": "tsc && vite build",
+    "build-demo": "tsc && vite build --base=/cunningham/demo/",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/predeploy-ghpages
+++ b/scripts/predeploy-ghpages
@@ -1,9 +1,15 @@
 rm -rf ghpages-output
-mkdir -p ghpages-output/storybook
 
+mkdir -p ghpages-output/storybook
 cd packages/react && yarn build-storybook
 cd ../..
 mv packages/react/storybook-static/* ghpages-output/storybook
 
+mkdir -p ghpages-output/demo
+cd apps/demo && yarn build-demo
+cd ../..
+mv apps/demo/dist/* ghpages-output/demo
+
 touch ./ghpages-output/.nojekyll
 touch ./ghpages-output/storybook/.nojekyll
+touch ./ghpages-output/demo/.nojekyll


### PR DESCRIPTION
As we deploy the demo site on gh-pages we now want to provide a link on the main README.
