### PR TITLE
🏷️(react) remove ModalFooter export

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -140,11 +140,7 @@ export const Modal = (props: ModalProps) => {
   );
 };
 
-export const ModalFooter = ({
-  leftActions,
-  rightActions,
-  actions,
-}: ModalProps) => {
+const ModalFooter = ({ leftActions, rightActions, actions }: ModalProps) => {
   if ((leftActions || rightActions) && actions) {
     throw new Error("Cannot use leftActions or rightActions with actions");
   }


### PR DESCRIPTION
This component was not supposed to be exported, it could be misleading for consumers.

Fixes #258