### PR TITLE
💄(react) make Modal close button sticky

### DIFF
--- a/.changeset/early-timers-march.md
+++ b/.changeset/early-timers-march.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+make Modal close button sticky

--- a/packages/react/src/components/Modal/index.scss
+++ b/packages/react/src/components/Modal/index.scss
@@ -69,9 +69,19 @@
   }
 
   &__close {
-    position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
+    position: sticky;
+    top: 0;
+    display: flex;
+    justify-content: end;
+    z-index: 1;
+    height: 0;
+
+    .c__button {
+      right: -0.75rem;
+      top: -0.75rem;
+      position: relative;
+      background: var(--c--components--modal--background-color);
+    }
   }
 
   &__footer {

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -132,7 +132,7 @@ export const ModalInner = (props: ModalProps) => {
                 <Button
                   icon={<span className="material-icons">close</span>}
                   color="tertiary-text"
-                  size="nano"
+                  size="small"
                   onClick={() => props.onClose()}
                 />
               </div>


### PR DESCRIPTION
We want to make sure this button is always visible inside scrollable modals.

Fixes #278

<img width="636" alt="Capture d’écran 2024-02-28 à 12 22 58" src="https://github.com/openfun/cunningham/assets/9628870/2dbe04a9-f825-4ecd-98bb-b3f49f136c22">
