### PR TITLE
🚨(react) fix CSS end warning usage

### DIFF
--- a/.changeset/strong-bears-kneel.md
+++ b/.changeset/strong-bears-kneel.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+fix CSS end warning usage

--- a/packages/react/src/components/Modal/index.scss
+++ b/packages/react/src/components/Modal/index.scss
@@ -72,7 +72,7 @@
     position: sticky;
     top: 0;
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     z-index: 1;
     height: 0;
 


### PR DESCRIPTION
Next.js is warning about the usage of end instead of flex-end during compilation.

Fixes #291