### PR TITLE
✨(react) add sorting on custom cells + add warning when onSortModelChange is missing

### DIFF
--- a/.changeset/chatty-rabbits-remember.md
+++ b/.changeset/chatty-rabbits-remember.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+add warning on DataGrid when sortModel is missing

--- a/.changeset/tall-glasses-attack.md
+++ b/.changeset/tall-glasses-attack.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": minor
+---
+
+add sorting on custom columns

--- a/packages/react/src/components/DataGrid/DataList.tsx
+++ b/packages/react/src/components/DataGrid/DataList.tsx
@@ -2,5 +2,15 @@ import React from "react";
 import { BaseProps, DataGrid, Row } from ":/components/DataGrid/index";
 
 export const DataList = <T extends Row>({ rows, ...props }: BaseProps<T>) => {
-  return <DataGrid {...props} displayHeader={false} rows={rows} />;
+  return (
+    <DataGrid
+      {...props}
+      displayHeader={false}
+      rows={rows}
+      columns={props.columns.map((column) => ({
+        ...column,
+        enableSorting: false,
+      }))}
+    />
+  );
 };

--- a/packages/react/src/components/DataGrid/index.stories.tsx
+++ b/packages/react/src/components/DataGrid/index.stories.tsx
@@ -195,6 +195,7 @@ export const FullServerSide = () => {
         lastName: faker.person.lastName(),
         email: faker.internet.email(),
         address: faker.location.streetAddress(),
+        country: faker.location.countryCode(),
       })),
     [],
   );
@@ -260,6 +261,24 @@ export const FullServerSide = () => {
         {
           field: "address",
           headerName: "Address",
+        },
+        {
+          headerName: "Country",
+          field: "country",
+          renderCell: (context) => {
+            return (
+              <span
+                style={{ display: "flex", alignItems: "center", gap: "8px" }}
+              >
+                <img
+                  style={{ height: "24px" }}
+                  src={`https://flagsapi.com/${context.row.country}/shiny/64.png`}
+                  alt="Flag"
+                />
+                {context.row.country}
+              </span>
+            );
+          },
         },
         {
           id: "actions",

--- a/packages/react/src/components/DataGrid/index.tsx
+++ b/packages/react/src/components/DataGrid/index.tsx
@@ -92,6 +92,14 @@ export const DataGrid = <T extends Row>({
   const { t } = useCunningham();
   const headlessColumns = useHeadlessColumns({ columns, enableRowSelection });
 
+  headlessColumns.forEach((column) => {
+    if (column.enableSorting && !onSortModelChange) {
+      console.warn(
+        "You are using a column with sorting enabled, but you are not providing an `onSortModelChange` handler. The sorting will not work as expected.",
+      );
+    }
+  });
+
   /**
    * Features.
    */

--- a/packages/react/src/components/DataGrid/index.tsx
+++ b/packages/react/src/components/DataGrid/index.tsx
@@ -30,12 +30,19 @@ export interface ColumnField {
 }
 
 export interface ColumnCustomCell<T extends Row = Row> {
+  id?: string;
+  field: string;
+  renderCell: (params: { row: T }) => React.ReactNode;
+}
+export interface ColumnDisplayCell<T extends Row = Row> {
   id: string;
+  field?: never;
   renderCell: (params: { row: T }) => React.ReactNode;
 }
 
 export type Column<T extends Row = Row> = (
   | ColumnCustomCell<T>
+  | ColumnDisplayCell<T>
   | ColumnField
 ) & {
   headerName?: string;

--- a/packages/react/src/components/DataGrid/utils.tsx
+++ b/packages/react/src/components/DataGrid/utils.tsx
@@ -28,7 +28,8 @@ export const useHeadlessColumns = <T extends Row>({
     const id = (column.id ?? column.field) as string;
     const opts = {
       id,
-      enableSorting: column.enableSorting,
+      enableSorting:
+        column.enableSorting === undefined ? true : column.enableSorting,
       header: column.headerName,
       cell: (info: CellContext<any, any>) => {
         if (column.renderCell) {


### PR DESCRIPTION
Previously sorting on custom cells was not possible because they were considered as "display cells" by React-Table, which is made for actions columns, which aren't sortable.