### PR TITLE
✨(react) add async mode to Select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist
 *.njsproj
 *.sln
 *.sw?
+*.tool-versions
 
 vite.config.ts.timestamp-*
 env.d

--- a/packages/react/src/components/Forms/Select/index.tsx
+++ b/packages/react/src/components/Forms/Select/index.tsx
@@ -24,10 +24,12 @@ export type OptionWithoutRender = Omit<BaseOption, "value" | "render"> & {
 export type Option = OptionWithoutRender | OptionWithRender;
 
 export type ContextOptionAsaCallback = {
-  search?: string | undefined
-}
+  search?: string | undefined;
+};
 
-export type OptionAsaCallback = (context: ContextOptionAsaCallback) => Promise<Option[]>;
+export type OptionAsaCallback = (
+  context: ContextOptionAsaCallback,
+) => Promise<Option[]>;
 
 export interface SelectHandle {
   blur: () => void;

--- a/packages/react/src/components/Forms/Select/index.tsx
+++ b/packages/react/src/components/Forms/Select/index.tsx
@@ -23,6 +23,12 @@ export type OptionWithoutRender = Omit<BaseOption, "value" | "render"> & {
 
 export type Option = OptionWithoutRender | OptionWithRender;
 
+export type ContextOptionAsaCallback = {
+  search?: string | undefined
+}
+
+export type OptionAsaCallback = (context: ContextOptionAsaCallback) => Promise<Option[]>;
+
 export interface SelectHandle {
   blur: () => void;
 }
@@ -31,7 +37,7 @@ export type SelectProps = PropsWithChildren &
   FieldProps & {
     label: string;
     hideLabel?: boolean;
-    options: Option[];
+    options: Option[] | OptionAsaCallback;
     searchable?: boolean;
     name?: string;
     defaultValue?: string | number | string[];

--- a/packages/react/src/components/Forms/Select/mono-searchable.tsx
+++ b/packages/react/src/components/Forms/Select/mono-searchable.tsx
@@ -15,13 +15,20 @@ import {
   SelectMonoAux,
   SubProps,
 } from ":/components/Forms/Select/mono-common";
-import { SelectHandle } from ":/components/Forms/Select";
+import {
+  ContextOptionAsaCallback,
+  Option,
+  OptionAsaCallback,
+  SelectHandle,
+} from ":/components/Forms/Select";
 import { isOptionWithRender } from ":/components/Forms/Select/utils";
 
 export const SelectMonoSearchable = forwardRef<SelectHandle, SubProps>(
   ({ showLabelWhenSelected = true, ...props }, ref) => {
     const { t } = useCunningham();
-    const [optionsToDisplay, setOptionsToDisplay] = useState(props.options);
+    const [optionsToDisplay, setOptionsToDisplay] = useState<Option[]>(
+      Array.isArray(props.options) ? props.options : [],
+    );
     const [hasInputFocused, setHasInputFocused] = useState(false);
     const [inputFilter, setInputFilter] = useState<string>();
     const inputRef = useRef<HTMLInputElement>(null);
@@ -39,6 +46,15 @@ export const SelectMonoSearchable = forwardRef<SelectHandle, SubProps>(
     const [labelAsPlaceholder, setLabelAsPlaceholder] = useState(
       !downshiftReturn.selectedItem,
     );
+
+    const computeOptionsToDisplay = async (
+      context: ContextOptionAsaCallback,
+    ): Promise<void> => {
+      const arrayOptions = await (props.options as OptionAsaCallback)(context);
+
+      setOptionsToDisplay(arrayOptions);
+    };
+
     useEffect(() => {
       if (hasInputFocused || downshiftReturn.inputValue) {
         setLabelAsPlaceholder(false);
@@ -57,30 +73,39 @@ export const SelectMonoSearchable = forwardRef<SelectHandle, SubProps>(
         return;
       }
 
-      const selectedItem = downshiftReturn.selectedItem
-        ? optionToValue(downshiftReturn.selectedItem)
-        : undefined;
+      if (Array.isArray(props.options)) {
+        const selectedItem = downshiftReturn.selectedItem
+          ? optionToValue(downshiftReturn.selectedItem)
+          : undefined;
 
-      const optionToSelect = props.options.find(
-        (option) => optionToValue(option) === props.value,
-      );
+        const optionToSelect = props.options.find(
+          (option) => optionToValue(option) === props.value,
+        );
 
-      // Already selected
-      if (optionToSelect && selectedItem === props.value) {
-        return;
+        // Already selected
+        if (optionToSelect && selectedItem === props.value) {
+          return;
+        }
+
+        downshiftReturn.selectItem(optionToSelect ?? null);
       }
-
-      downshiftReturn.selectItem(optionToSelect ?? null);
     }, [props.value, props.options, inputFilter]);
 
     // Even there is already a value selected, when opening the combobox menu we want to display all available choices.
     useEffect(() => {
       if (downshiftReturn.isOpen) {
-        setOptionsToDisplay(
-          inputFilter
-            ? props.options.filter(getOptionsFilter(inputFilter))
-            : props.options,
-        );
+        if (Array.isArray(props.options))
+          setOptionsToDisplay(
+            inputFilter
+              ? props.options.filter(getOptionsFilter(inputFilter))
+              : props.options,
+          );
+
+        if (typeof props.options === "function") {
+          (async () => {
+            await computeOptionsToDisplay({ search: inputFilter });
+          })();
+        }
       } else {
         setInputFilter(undefined);
       }
@@ -115,6 +140,12 @@ export const SelectMonoSearchable = forwardRef<SelectHandle, SubProps>(
     });
 
     const renderCustomSelectedOption = !showLabelWhenSelected;
+
+    if (typeof props.options === "function") {
+      (async () => {
+        await computeOptionsToDisplay({ search: inputFilter });
+      })();
+    }
 
     return (
       <SelectMonoAux

--- a/packages/react/src/components/Forms/Select/mono-simple.tsx
+++ b/packages/react/src/components/Forms/Select/mono-simple.tsx
@@ -11,14 +11,18 @@ import {
   SelectMonoAux,
   SubProps,
 } from ":/components/Forms/Select/mono-common";
-import { SelectHandle } from ":/components/Forms/Select";
+import { Option, SelectHandle } from ":/components/Forms/Select";
 import { SelectedOption } from ":/components/Forms/Select/utils";
 
 export const SelectMonoSimple = forwardRef<SelectHandle, SubProps>(
   (props, ref) => {
+    const arrayOptions: Option[] = Array.isArray(props.options)
+      ? props.options
+      : [];
+
     const downshiftReturn = useSelect({
       ...props.downshiftProps,
-      items: props.options,
+      items: arrayOptions,
       itemToString: optionToString,
     });
 
@@ -28,7 +32,7 @@ export const SelectMonoSimple = forwardRef<SelectHandle, SubProps>(
         ? optionToValue(downshiftReturn.selectedItem)
         : undefined;
 
-      const optionToSelect = props.options.find(
+      const optionToSelect = arrayOptions.find(
         (option) => optionToValue(option) === props.value,
       );
 
@@ -38,7 +42,7 @@ export const SelectMonoSimple = forwardRef<SelectHandle, SubProps>(
       }
 
       downshiftReturn.selectItem(optionToSelect ?? null);
-    }, [props.value, props.options]);
+    }, [props.value, arrayOptions]);
 
     const wrapperRef = useRef<HTMLElement>(null);
 
@@ -52,6 +56,7 @@ export const SelectMonoSimple = forwardRef<SelectHandle, SubProps>(
     return (
       <SelectMonoAux
         {...props}
+        options={arrayOptions}
         downshiftReturn={{
           ...downshiftReturn,
           wrapperProps: downshiftReturn.getToggleButtonProps({

--- a/packages/react/src/components/Forms/Select/mono.spec.tsx
+++ b/packages/react/src/components/Forms/Select/mono.spec.tsx
@@ -7,7 +7,8 @@ import {
   Select,
   Option,
   SelectHandle,
-  SelectProps, OptionAsaCallback, ContextOptionAsaCallback,
+  SelectProps,
+  OptionAsaCallback,
 } from ":/components/Forms/Select/index";
 import { Button } from ":/components/Button";
 import { CunninghamProvider } from ":/components/Provider";
@@ -1019,52 +1020,52 @@ describe("<Select/>", () => {
     });
 
     it("gets the search term using onSearchInputChange through an async function provided as the options prop", async () => {
-      const optionAsaCallback: OptionAsaCallback = async(context)  => new Promise(resolve => {
-        let arrayCities = [
-          {
-            label: "Paris",
-            value: "paris",
-          },
-          {
-            label: "Panama",
-            value: "panama",
-          },
-          {
-            label: "London",
-            value: "london",
-          },
-          {
-            label: "New York",
-            value: "new_york",
-          },
-          {
-            label: "Tokyo",
-            value: "tokyo",
-          },
-        ]
+      const optionAsaCallback: OptionAsaCallback = async (context) =>
+        new Promise((resolve) => {
+          const arrayCities = [
+            {
+              label: "Paris",
+              value: "paris",
+            },
+            {
+              label: "Panama",
+              value: "panama",
+            },
+            {
+              label: "London",
+              value: "london",
+            },
+            {
+              label: "New York",
+              value: "new_york",
+            },
+            {
+              label: "Tokyo",
+              value: "tokyo",
+            },
+          ];
 
-        // simulate a delayed response
-        setTimeout(() => {
-          const searchTerm = context?.search ?? undefined;
+          // simulate a delayed response
+          setTimeout(() => {
+            const stringSearch = context?.search ?? "";
 
-          const filterOptions = (arrayOptions: Option[], searchTerm: string) => arrayOptions
-            .filter(option => option.label.toLocaleLowerCase().includes(searchTerm.toLowerCase())
-          );
+            const filterOptions = (arrayOptions: Option[], search: string) =>
+              arrayOptions.filter((option) =>
+                option.label.toLocaleLowerCase().includes(search.toLowerCase()),
+              );
 
-          let arrayOptions: Option[] = searchTerm ? filterOptions(arrayCities, searchTerm) : arrayCities;
+            const arrayOptions: Option[] = stringSearch
+              ? filterOptions(arrayCities, stringSearch)
+              : arrayCities;
 
-          resolve(arrayOptions);
-        }, 1)
-      })
+            resolve(arrayOptions);
+          }, 1);
+        });
 
       const user = userEvent.setup();
       render(
         <CunninghamProvider>
-          <Select
-            label="City"
-            options={optionAsaCallback}
-            searchable={true}
-          />
+          <Select label="City" options={optionAsaCallback} searchable={true} />
         </CunninghamProvider>,
       );
 

--- a/packages/react/src/components/Forms/Select/mono.spec.tsx
+++ b/packages/react/src/components/Forms/Select/mono.spec.tsx
@@ -7,7 +7,7 @@ import {
   Select,
   Option,
   SelectHandle,
-  SelectProps,
+  SelectProps, OptionAsaCallback, ContextOptionAsaCallback,
 } from ":/components/Forms/Select/index";
 import { Button } from ":/components/Button";
 import { CunninghamProvider } from ":/components/Provider";
@@ -1016,6 +1016,92 @@ describe("<Select/>", () => {
       });
       await user.click(option);
       expect(searchTerm).toBeUndefined();
+    });
+
+    it("gets the search term using onSearchInputChange through an async function provided as the options prop", async () => {
+      const optionAsaCallback: OptionAsaCallback = async(context)  => new Promise(resolve => {
+        let arrayCities = [
+          {
+            label: "Paris",
+            value: "paris",
+          },
+          {
+            label: "Panama",
+            value: "panama",
+          },
+          {
+            label: "London",
+            value: "london",
+          },
+          {
+            label: "New York",
+            value: "new_york",
+          },
+          {
+            label: "Tokyo",
+            value: "tokyo",
+          },
+        ]
+
+        // simulate a delayed response
+        setTimeout(() => {
+          const searchTerm = context?.search ?? undefined;
+
+          const filterOptions = (arrayOptions: Option[], searchTerm: string) => arrayOptions
+            .filter(option => option.label.toLocaleLowerCase().includes(searchTerm.toLowerCase())
+          );
+
+          let arrayOptions: Option[] = searchTerm ? filterOptions(arrayCities, searchTerm) : arrayCities;
+
+          resolve(arrayOptions);
+        }, 1)
+      })
+
+      const user = userEvent.setup();
+      render(
+        <CunninghamProvider>
+          <Select
+            label="City"
+            options={optionAsaCallback}
+            searchable={true}
+          />
+        </CunninghamProvider>,
+      );
+
+      const input = screen.getByRole("combobox", {
+        name: "City",
+      });
+
+      // It returns the input.
+      expect(input.tagName).toEqual("INPUT");
+
+      const menu: HTMLDivElement = screen.getByRole("listbox", {
+        name: "City",
+      });
+
+      expectMenuToBeClosed(menu);
+
+      // Click on the input.
+      await user.click(input);
+      expectMenuToBeOpen(menu);
+
+      expectOptions(["Paris", "Panama", "London", "New York", "Tokyo"]);
+
+      // Verify that filtering works.
+      await user.type(input, "Pa");
+      expectMenuToBeOpen(menu);
+      expectOptions(["Paris", "Panama"]);
+
+      await user.type(input, "r", { skipClick: true });
+      expectOptions(["Paris"]);
+
+      // Select option.
+      const option: HTMLLIElement = screen.getByRole("option", {
+        name: "Paris",
+      });
+      await user.click(option);
+
+      expect(input).toHaveValue("Paris");
     });
   });
 

--- a/packages/react/src/components/Forms/Select/mono.stories.tsx
+++ b/packages/react/src/components/Forms/Select/mono.stories.tsx
@@ -5,7 +5,12 @@ import * as Yup from "yup";
 import { faker } from "@faker-js/faker";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { onSubmit } from ":/components/Forms/Examples/ReactHookForm/reactHookFormUtils";
-import { Select, SelectHandle } from ":/components/Forms/Select";
+import {
+  ContextOptionAsaCallback,
+  Option,
+  Select,
+  SelectHandle,
+} from ":/components/Forms/Select";
 import { Button } from ":/components/Button";
 import {
   getCountryOption,
@@ -129,6 +134,57 @@ export const SearchableUncontrolled = {
   args: {
     label: "Select a city",
     options: OPTIONS,
+    defaultValue: OPTIONS[4].value,
+    searchable: true,
+  },
+};
+
+export const AsyncSearchableUncontrolled = {
+  render: Template,
+
+  args: {
+    label: "Select a city",
+    options: async (context: ContextOptionAsaCallback) =>
+      new Promise((resolve) => {
+        const arrayCities = [
+          {
+            label: "Paris",
+            value: "paris",
+          },
+          {
+            label: "Panama",
+            value: "panama",
+          },
+          {
+            label: "London",
+            value: "london",
+          },
+          {
+            label: "New York",
+            value: "new_york",
+          },
+          {
+            label: "Tokyo",
+            value: "tokyo",
+          },
+        ];
+
+        // simulate a delayed response
+        setTimeout(() => {
+          const stringSearch = context?.search ?? undefined;
+
+          const filterOptions = (arrayOptions: Option[], search: string) =>
+            arrayOptions.filter((option) =>
+              option.label.toLocaleLowerCase().includes(search.toLowerCase()),
+            );
+
+          const arrayOptions: Option[] = stringSearch
+            ? filterOptions(arrayCities, stringSearch)
+            : arrayCities;
+
+          resolve(arrayOptions);
+        }, 500);
+      }),
     defaultValue: OPTIONS[4].value,
     searchable: true,
   },

--- a/packages/react/src/components/Forms/Select/mono.tsx
+++ b/packages/react/src/components/Forms/Select/mono.tsx
@@ -7,7 +7,9 @@ import { Option, SelectHandle, SelectProps } from ":/components/Forms/Select";
 
 export const SelectMono = forwardRef<SelectHandle, SelectProps>(
   (props, ref) => {
-    const arrayOptions = Array.isArray(props.options) ? props.options : [];
+    const arrayOptions: Option[] = Array.isArray(props.options)
+      ? props.options
+      : [];
 
     const defaultSelectedItem = props.defaultValue
       ? arrayOptions.find(

--- a/packages/react/src/components/Forms/Select/mono.tsx
+++ b/packages/react/src/components/Forms/Select/mono.tsx
@@ -7,8 +7,10 @@ import { Option, SelectHandle, SelectProps } from ":/components/Forms/Select";
 
 export const SelectMono = forwardRef<SelectHandle, SelectProps>(
   (props, ref) => {
+    const arrayOptions = Array.isArray(props.options) ? props.options : [];
+
     const defaultSelectedItem = props.defaultValue
-      ? props.options.find(
+      ? arrayOptions.find(
           (option) => optionToValue(option) === props.defaultValue,
         )
       : undefined;
@@ -58,6 +60,7 @@ export const SelectMono = forwardRef<SelectHandle, SelectProps>(
     ) : (
       <SelectMonoSimple
         {...props}
+        options={arrayOptions}
         downshiftProps={commonDownshiftProps}
         value={value}
         ref={ref}

--- a/packages/react/src/components/Forms/Select/multi-searchable.tsx
+++ b/packages/react/src/components/Forms/Select/multi-searchable.tsx
@@ -20,9 +20,11 @@ export const SelectMultiSearchable = forwardRef<SelectHandle, SubProps>(
     const inputRef = useRef<HTMLInputElement>(null);
     const options = React.useMemo(
       () =>
-        props.options.filter(
-          getMultiOptionsFilter(props.selectedItems, inputValue),
-        ),
+        Array.isArray(props.options)
+          ? props.options.filter(
+              getMultiOptionsFilter(props.selectedItems, inputValue),
+            )
+          : [],
       [props.selectedItems, inputValue],
     );
     const [hasInputFocused, setHasInputFocused] = useState(false);

--- a/packages/react/src/components/Forms/Select/multi-simple.tsx
+++ b/packages/react/src/components/Forms/Select/multi-simple.tsx
@@ -13,6 +13,10 @@ import { Option, SelectHandle } from ":/components/Forms/Select/index";
 
 export const SelectMultiSimple = forwardRef<SelectHandle, SubProps>(
   (props, ref) => {
+    const arrayOptions: Option[] = Array.isArray(props.options)
+      ? props.options
+      : [];
+
     const isSelected = (option: Option) =>
       !!props.selectedItems.find((selectedItem) =>
         optionsEqual(selectedItem, option),
@@ -20,12 +24,12 @@ export const SelectMultiSimple = forwardRef<SelectHandle, SubProps>(
 
     const options = React.useMemo(() => {
       if (props.monoline) {
-        return props.options.map((option) => ({
+        return arrayOptions.map((option) => ({
           ...option,
           highlighted: isSelected(option),
         }));
       }
-      return props.options.filter(
+      return arrayOptions.filter(
         getMultiOptionsFilter(props.selectedItems, ""),
       );
     }, [props.selectedItems]);

--- a/packages/react/src/components/Forms/Select/multi.tsx
+++ b/packages/react/src/components/Forms/Select/multi.tsx
@@ -17,9 +17,11 @@ export const SelectMulti = forwardRef<SelectHandle, SelectMultiProps>(
   (props, ref) => {
     const getSelectedItemsFromProps = () => {
       const valueToUse = props.defaultValue ?? props.value ?? [];
-      return props.options.filter((option) =>
-        (valueToUse as string[]).includes(optionToValue(option)),
-      );
+      return Array.isArray(props.options)
+        ? props.options.filter((option) =>
+            (valueToUse as string[]).includes(optionToValue(option)),
+          )
+        : [];
     };
 
     const [selectedItems, setSelectedItems] = React.useState<Option[]>(


### PR DESCRIPTION
An uncontrolled mono select component can now take
a callback as an options prop to fetch data and format
them as an array of options to display.

Related to issue [286](https://github.com/openfun/cunningham/issues/286).
