### PR TITLE
🔧(react) remove Misc stories from Storybook sidebar

### DIFF
--- a/packages/react/.storybook/manager.tsx
+++ b/packages/react/.storybook/manager.tsx
@@ -32,3 +32,13 @@ addons.register('theme-synchronizer', () => {
         },
     });
 });
+
+addons.setConfig({
+    sidebar: {
+        filters: {
+            hidden: item => {
+                return !item.title.startsWith('Misc/');
+            }
+        }
+    }
+});

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -42,7 +42,7 @@ const preview: Preview = {
         },
         options: {
             storySort: (a, b) => {
-                const roots = ['Getting Started', 'Components', 'Migrating', 'Misc'];
+                const roots = ['Getting Started', 'Components', 'Migrating'];
                 const gettingStartedOrder = [
                     'Installation',
                     'First steps',


### PR DESCRIPTION
These files include stories only used from regular documentation, they have no other purpose so we decided to hide them.