### PR TITLE
🐛(modal) make modal scrollable when height exceeds the viewport height

### DIFF
--- a/.changeset/poor-hats-hammer.md
+++ b/.changeset/poor-hats-hammer.md
@@ -1,5 +1,0 @@
----
-"@openfun/cunningham-react": patch
----
-
-Fix modal scroller height issue that prevent modal to be scrollable with high content

--- a/.changeset/poor-hats-hammer.md
+++ b/.changeset/poor-hats-hammer.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+Fix modal scroller height issue that prevent modal to be scrollable with high content

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openfun/cunningham-react
 
+## 2.9.2
+
+### Patch Changes
+
+- cba9ca8: Fix modal scroller height issue that prevent modal to be scrollable with high content
+
 ## 2.9.1
 
 ### Patch Changes
@@ -405,7 +411,8 @@
 - 4ebbf16: Add package
 - 4ebbf16: Add component's tokens handling
 
-[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@2.9.1...main
+[unreleased]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@2.9.2...main
+[2.9.2]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@2.9.1...@openfun/cunningham-react@2.9.2
 [2.9.1]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@2.9.0...@openfun/cunningham-react@2.9.1
 [2.9.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@2.8.0...@openfun/cunningham-react@2.9.0
 [2.8.0]: https://github.com/openfun/cunningham/compare/@openfun/cunningham-react@2.7.0...@openfun/cunningham-react@2.8.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfun/cunningham-react",
   "private": false,
-  "version": "2.9.1",
+  "version": "2.9.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react/src/components/Modal/index.scss
+++ b/packages/react/src/components/Modal/index.scss
@@ -12,10 +12,12 @@
   top: 50%;
   transform: translate(-50%, -50%);
   max-width: calc(100% - 2em - 6px);
+  max-height: calc(100% - 2em - 6px);
+  display: flex;
+  flex-direction: column;
 
   &__scroller {
     padding: 1.5rem;
-    max-height: calc(100% - 2em - 6px);
     overflow: auto;
   }
 


### PR DESCRIPTION
Currently, if the content of a modal exceeds the viewport height, it is
not scrollable.

Then create a patch release of @openfun/cunningham-react