### PR TITLE
💄(react) use overflow auto instead of scroll

### DIFF
--- a/.changeset/fair-melons-exercise.md
+++ b/.changeset/fair-melons-exercise.md
@@ -1,5 +1,0 @@
----
-"@openfun/cunningham-react": patch
----
-
-make datagrid select column visible

--- a/.changeset/hip-masks-love.md
+++ b/.changeset/hip-masks-love.md
@@ -1,5 +1,0 @@
----
-"@openfun/cunningham-react": patch
----
-
-Use `overflow:auto` instead of `overflow:scroll`

--- a/.changeset/hip-masks-love.md
+++ b/.changeset/hip-masks-love.md
@@ -1,0 +1,5 @@
+---
+"@openfun/cunningham-react": patch
+---
+
+Use `overflow:auto` instead of `overflow:scroll`

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openfun/cunningham-react
 
+## 2.9.4
+
+### Patch Changes
+
+- 1514e4f: make datagrid select column visible
+- b374eb8: Use `overflow:auto` instead of `overflow:scroll`
+
 ## 2.9.3
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openfun/cunningham-react",
   "private": false,
-  "version": "2.9.3",
+  "version": "2.9.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react/src/components/DataGrid/_index.scss
+++ b/packages/react/src/components/DataGrid/_index.scss
@@ -17,7 +17,7 @@
 
   &__table__container {
     width: 100%;
-    overflow: scroll;
+    overflow: auto;
 
     > table {
       border-collapse: collapse;

--- a/packages/react/src/components/Tooltip/_index.scss
+++ b/packages/react/src/components/Tooltip/_index.scss
@@ -74,7 +74,7 @@
   }
 
   &__content {
-    overflow: scroll;
+    overflow: auto;
   }
 }
 


### PR DESCRIPTION
Currently, Tooltip and Datagrid components are set to always display scroll bar.
This is weird, as the scrollbar is always shown even if this is not
needed. Instead, we use `auto` value to display it only when
it is needed

Then prepare a patch release of `@openfun/cunningham-react`