### PR TITLE
Make React a peer dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,6 +41,10 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
+  "peerDependencies": {
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
   "dependencies": {
     "@fontsource-variable/roboto-flex": "5.2.5",
     "@fontsource/material-icons-outlined": "5.2.5",
@@ -56,10 +60,8 @@
     "chromatic": "11.27.0",
     "classnames": "2.5.1",
     "downshift": "9.0.9",
-    "react": "19.0.0",
     "react-aria": "3.38.1",
     "react-aria-components": "1.7.1",
-    "react-dom": "19.0.0",
     "react-modal": "3.16.3",
     "react-stately": "3.36.1"
   },


### PR DESCRIPTION
There is a [wide](https://stackoverflow.com/questions/30451556/what-is-the-correct-way-of-adding-react-as-a-dependency-in-the-package-json) [consensus](https://blog.bitsrc.io/understanding-peer-dependencies-in-javascript-dbdb4ab5a7be) that react and react-dom should be declared as peerDependencies, and declared in devDependencies as well when [using TypeScript](https://dev.to/jody/a-tip-on-using-peer-dependencies-with-typescript-2bji).

This PR is submitted also in the hope that this will lead the Renovate bot to do the right thing(s) for https://github.com/numerique-gouv/people and a bunch of other projects in https://github.com/numerique-gouv/ and alleviate problems that can occur when these projects end up with discordant versions of React.