### PR TITLE
♿️(modal) remove duplicated ids

### DIFF
--- a/packages/react/src/components/Modal/ModalProvider.tsx
+++ b/packages/react/src/components/Modal/ModalProvider.tsx
@@ -163,7 +163,7 @@ export const ModalProvider = ({
         if (modalParentSelector) {
           return modalParentSelector();
         }
-        return document.getElementById("c__modals-portal")!;
+        return document.querySelector(".c__modals-portal")!;
       },
     }),
     [],
@@ -172,7 +172,7 @@ export const ModalProvider = ({
   return (
     <ModalContext.Provider value={context}>
       {children}
-      <div id="c__modals-portal" />
+      <div className="c__modals-portal" />
       {Object.entries(modals).map(([key, modal]) => (
         <Fragment key={key}>{modal}</Fragment>
       ))}


### PR DESCRIPTION
Instead of using an ID to identify a modal, use a class instead to avoid creating a situation where there are duplicated ids.

https://github.com/openfun/cunningham/issues/352