### PR TITLE
⚡️(react) remove base64 font imports

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,8 +46,6 @@
     "react-dom": "19.1.0"
   },
   "dependencies": {
-    "@fontsource-variable/roboto-flex": "5.2.5",
-    "@fontsource/material-icons-outlined": "5.2.5",
     "@internationalized/date": "3.8.0",
     "@openfun/cunningham-tokens": "*",
     "@react-aria/calendar": "3.8.0",

--- a/packages/react/src/fonts.scss
+++ b/packages/react/src/fonts.scss
@@ -1,1 +1,1 @@
-@use "@fontsource-variable/roboto-flex";
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,100..1000&display=swap');

--- a/packages/react/src/icons.scss
+++ b/packages/react/src/icons.scss
@@ -1,4 +1,4 @@
-@use "@fontsource/material-icons-outlined";
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons+Outlined&display=swap');
 
 .material-icons {
   font-family: 'Material Icons Outlined';

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,16 +994,6 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.7.0.tgz#1cf1fecfcad5e2da2332140bf3b5f23cc1c2a7f4"
   integrity sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==
 
-"@fontsource-variable/roboto-flex@5.2.5":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@fontsource-variable/roboto-flex/-/roboto-flex-5.2.5.tgz#38368ea754697c2fdf08df11b06e8b6d391ff4c1"
-  integrity sha512-yrZ9rWNvfM4IBqJSpoFV4wC1GaKNwpzhihyBke+N3WiA0Y7LYxwj6kvvHgecabVIHFL3ZZJTwj3KcKOCyASFPg==
-
-"@fontsource/material-icons-outlined@5.2.5":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@fontsource/material-icons-outlined/-/material-icons-outlined-5.2.5.tgz#16b4b2a8dcd1fbd69d4182792a65f7b41b8cb230"
-  integrity sha512-soAUWorSKrLN0a7wk74pedV0ZxhLaMD40DuUTMIqTpDcdJ/pxaG+/OcXtMEzx2+5K5FwL7yS525ZInAzPG051Q==
-
 "@formatjs/ecma402-abstract@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.2.tgz#0ee291effe7ee2c340742a6c95d92eacb5e6c00a"


### PR DESCRIPTION
## Proposal

Remove base64 font imports from the Cunningham React package and replace them with Google Fonts imports.
This change improves performance by reducing the bundle size and leveraging browser caching for fonts.

## File Size Reduction

- `font.css` from 139KB to 1KB
- `icons.css` from 440KB to 1KB

Improved first render performance: No more large base64 fonts blocking initial load
Better caching: Google Fonts are cached globally by users' browsers
Reduced bandwidth usage: Fonts are served from Google's CDN
Maintainability: No more need to manage font file updates
