### PR TITLE
📌(react) update version strategy of peer deps

### DIFF
--- a/.changeset/purple-pants-divide.md
+++ b/.changeset/purple-pants-divide.md
@@ -1,0 +1,5 @@
+---
+"@gouvfr-lasuite/cunningham-react": patch
+---
+
+Update react & react-dom version strategy to support minor and patch verions

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,8 +42,8 @@
     "build-storybook": "storybook build"
   },
   "peerDependencies": {
-    "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "dependencies": {
     "@fontsource-variable/roboto-flex": "5.2.5",


### PR DESCRIPTION
Currently peer deps are pinned. This is pretty annoying as all app consumers must stick to the peer deps package version define in Cunningham and must wait that cunningham upgrades them to upgrade on their side. Allow to install minor and patch version of react & react-dom.