### PR TITLE
📱(react) do not hide subtitle modal tab on small viewport

### DIFF
--- a/.changeset/hungry-parents-dress.md
+++ b/.changeset/hungry-parents-dress.md
@@ -1,0 +1,5 @@
+---
+"@gouvfr-lasuite/cunningham-react": patch
+---
+
+Modal tab - Do not hide tab subtitle on small viewports

--- a/packages/react/src/components/Modal/index.scss
+++ b/packages/react/src/components/Modal/index.scss
@@ -472,15 +472,16 @@
           padding: var(--c--globals--spacings--sm);
         }
 
-        .c__modal__subtitle {
-          display: none;
-        }
-
         &__header {
           .c__modal__title {
             margin-bottom: 0;
             padding-right: 0;
           }
+
+        }
+
+        .c__modal__subtitle {
+          margin-top: var(--c--globals--spacings--2xs);
         }
 
         &__back {


### PR DESCRIPTION
Currently, the tab subtitle is hidden in modal tab on small viewports.