### PR TITLE
♿️(Select) hide dropdown arrow from tab order and screen readers

### DIFF
--- a/packages/react/src/components/Forms/Select/mono-common.tsx
+++ b/packages/react/src/components/Forms/Select/mono-common.tsx
@@ -133,7 +133,6 @@ export const SelectMonoAux = ({
           variant="tertiary"
           color="neutral"
           size="nano"
-          aria-label={t("components.forms.select.toggle_button_aria_label")}
           className="c__select__inner__actions__open"
           icon={
             <span
@@ -148,6 +147,8 @@ export const SelectMonoAux = ({
           disabled={disabled}
           type="button"
           {...downshiftReturn.toggleButtonProps}
+          aria-hidden={true}
+          tabIndex={-1}
         />
       </div>
     </div>

--- a/packages/react/src/components/Forms/Select/multi-common.tsx
+++ b/packages/react/src/components/Forms/Select/multi-common.tsx
@@ -107,7 +107,6 @@ export const SelectMultiAux = ({ children, ...props }: SelectMultiAuxProps) => {
           variant="tertiary"
           color="neutral"
           size="nano"
-          aria-label={t("components.forms.select.toggle_button_aria_label")}
           className="c__select__inner__actions__open"
           icon={
             <span
@@ -121,6 +120,8 @@ export const SelectMultiAux = ({ children, ...props }: SelectMultiAuxProps) => {
           }
           disabled={props.disabled}
           type="button"
+          aria-hidden={true}
+          tabIndex={-1}
         />
       </div>
       <div className="c__select__inner__value">


### PR DESCRIPTION
## Purpose

Remove duplicate focus stops on `Select` dropdown arrows for keyboard and screen reader users.

Before : 

https://github.com/user-attachments/assets/a568bc1a-c32e-4431-8db2-86a8b496f704

After : 

https://github.com/user-attachments/assets/aa0090c5-6e17-411a-9fed-b96087ab83c5


## Proposal

- [x] Hide arrow button from assistive tech (`aria-hidden`) and tab order (`tabIndex={-1}`) in mono and multi selects
- [x] Remove redundant `aria-label` on the decorative arrow

fixes : [https://github.com/suitenumerique/docs/issues/2342](2342)